### PR TITLE
Enable selection switching for single choice selectors

### DIFF
--- a/src/lib/atoms.ts
+++ b/src/lib/atoms.ts
@@ -612,7 +612,7 @@ export const toggleSelectedChoiceAtom = atom(null, (get, set, idx: number) => {
   if (!questionSelector) return;
 
   // 複数個の回答が存在する場合はidx番目のみ選択状態を反転し、
-  // 1つの回答のみが存在する場合はidx番目を選択・idx番目以外を未選択とする
+  // 1つの回答のみが存在する場合もidx番目の選択状態を反転し、idx番目以外を未選択とする
   set(questionSelectorAtom, {
     ...questionSelector,
     choices: questionSelector.choices.map(
@@ -622,7 +622,9 @@ export const toggleSelectedChoiceAtom = atom(null, (get, set, idx: number) => {
           ? i === idx
             ? !choice.isSelected
             : choice.isSelected
-          : i === idx,
+          : i === idx
+          ? !choice.isSelected
+          : false,
       })
     ),
   });

--- a/src/lib/atoms.ts
+++ b/src/lib/atoms.ts
@@ -623,8 +623,8 @@ export const toggleSelectedChoiceAtom = atom(null, (get, set, idx: number) => {
             ? !choice.isSelected
             : choice.isSelected
           : i === idx
-          ? !choice.isSelected
-          : false,
+            ? !choice.isSelected
+            : false,
       })
     ),
   });


### PR DESCRIPTION
Allow toggling selection for single-choice selectors (`isMultiplied=false`) in `toggleSelectedChoiceAtom` while maintaining the single-selection constraint.

Previously, in single-choice mode, selecting an already chosen item would keep it selected, preventing deselection. This change enables deselection by toggling the `isSelected` state when the same button is pressed again, ensuring only one item can be selected at a time.

---
<a href="https://cursor.com/background-agent?bcId=bc-56fdfc58-035e-4e55-9eaf-76a8aba82afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56fdfc58-035e-4e55-9eaf-76a8aba82afc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

