### PR TITLE
fix: 解説シートのセクション表示順を変更

### DIFF
--- a/swa/src/components/ExplanationSheetContent.tsx
+++ b/swa/src/components/ExplanationSheetContent.tsx
@@ -239,6 +239,24 @@ export default function ExplanationSheetContent() {
     answerExplanation &&
     !answerExplanation.isSubmitting && (
       <>
+        {answerExplanation.answerKeyPoint && (
+          <>
+            <h4 className="scroll-m-20 text-xl font-semibold tracking-tight my-4">
+              回答のポイント
+            </h4>
+            <div className="space-y-1">
+              <p className="leading-7">{answerExplanation.answerKeyPoint}</p>
+              {translationExplanation && translationExplanation.answerKeyPoint ? (
+                <p className="text-sm text-muted-foreground">
+                  {translationExplanation.answerKeyPoint}
+                </p>
+              ) : (
+                <Skeleton className="h-5 w-full" />
+              )}
+            </div>
+            <Separator className="my-6" />
+          </>
+        )}
         <h4 className="scroll-m-20 text-xl font-semibold tracking-tight my-4">
           選択肢と解説
         </h4>
@@ -282,24 +300,6 @@ export default function ExplanationSheetContent() {
             </Fragment>
           ))}
         </div>
-        {answerExplanation.answerKeyPoint && (
-          <>
-            <Separator className="my-6" />
-            <h4 className="scroll-m-20 text-xl font-semibold tracking-tight my-4">
-              回答のポイント
-            </h4>
-            <div className="space-y-1">
-              <p className="leading-7">{answerExplanation.answerKeyPoint}</p>
-              {translationExplanation && translationExplanation.answerKeyPoint ? (
-                <p className="text-sm text-muted-foreground">
-                  {translationExplanation.answerKeyPoint}
-                </p>
-              ) : (
-                <Skeleton className="h-5 w-full" />
-              )}
-            </div>
-          </>
-        )}
         <Separator className="my-6" />
         <div className="flex items-center justify-between my-4">
           <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`ExplanationSheetContent` の解説シート内で、セクションの上からの表示順を「回答のポイント」→「選択肢と解説」→「コミュニティ回答要約」に変更しました。

## 変更内容

- `answerKeyPoint` がある場合は先頭に「回答のポイント」ブロックを表示し、その直後に区切り線を配置
- 続けて「選択肢と解説」、区切り線、「コミュニティ回答要約」の順に表示（従来どおり）
- `answerKeyPoint` がない場合の見た目は、先頭が「選択肢と解説」から始まる従来と同様

## テスト内容

- 手動確認: 未実施（表示順の JSX 入れ替えのみ）
- 静的解析: `read_lints` による当該ファイルの診断で新規エラーなし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a3df69c-5f1c-4241-856b-d219d31f06ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a3df69c-5f1c-4241-856b-d219d31f06ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

