### PR TITLE
fix: テスト結果アコーディオンの矢印と正解アイコンの重なりを修正

### DIFF
--- a/swa/src/components/TestResultAccordion.tsx
+++ b/swa/src/components/TestResultAccordion.tsx
@@ -5,7 +5,7 @@ import { History } from "@/types/atoms";
 import { Favorite, GetFavoritesRes, GetQuestion } from "@/types/backend";
 import { useAccount, useMsal } from "@azure/msal-react";
 import { useAtomValue } from "jotai";
-import { Check, X } from "lucide-react";
+import { Check, ChevronDown, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router";
 import FavoriteButton from "./FavoriteButton";
@@ -141,17 +141,19 @@ export default function TestResultAccordion() {
           const isOpen = openHistoryIdxes.includes(historyKey);
 
           return (
-            <div
-              key={historyIdx}
-              className="collapse collapse-arrow border-b border-base-300"
-            >
+            <div key={historyIdx} className="collapse border-b border-base-300">
               <input
                 type="checkbox"
+                className="peer"
                 checked={isOpen}
                 onChange={(e) => handleToggle(historyKey, e.target.checked)}
               />
-              <div className="collapse-title flex items-center gap-2 pr-4">
-                <div className="pl-2 flex items-center shrink-0">
+              <div className="collapse-title flex min-h-0 items-center p-0">
+                <div
+                  className="flex items-center pl-4"
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => e.stopPropagation()}
+                >
                   <FavoriteButton
                     isFavorite={!!favorites && favorites[historyIdx]}
                     isLoading={favorites === undefined}
@@ -161,15 +163,24 @@ export default function TestResultAccordion() {
                     questionNumber={String(order[historyIdx])}
                   />
                 </div>
-                <h4 className="scroll-m-20 text-xl font-semibold tracking-tight flex-1">
-                  {`${historyIdx + 1}問目`}
-                </h4>
-                <div className="shrink-0">
-                  {history.isCorrect ? (
-                    <Check className="size-7 text-green-500" />
-                  ) : (
-                    <X className="size-7 text-red-500" />
-                  )}
+                <div className="flex flex-1 items-center justify-between px-4 py-4">
+                  <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+                    {`${historyIdx + 1}問目`}
+                  </h4>
+                  <div className="flex items-center gap-4">
+                    <div className="transform-none">
+                      {history.isCorrect ? (
+                        <Check className="size-7 text-green-500" />
+                      ) : (
+                        <X className="size-7 text-red-500" />
+                      )}
+                    </div>
+                    <ChevronDown
+                      className={`size-4 shrink-0 transition-transform duration-200 ${
+                        isOpen ? "rotate-180" : ""
+                      }`}
+                    />
+                  </div>
                 </div>
               </div>
               <TestResultAccordionContent


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

daisyUI 移行後の `TestResultPage` において、テスト結果アコーディオンの折りたたみ矢印（`collapse-arrow`）と正解/不正解アイコンが重なって表示されるデグレーションを修正しました。

## 変更内容

- `TestResultAccordion` から `collapse-arrow` を削除し、shadcn/ui 時代と同様に `ChevronDown` を明示配置
- お気に入りボタンをアコーディオントリガーの左側（`pl-4`）に分離
- 見出し・正解/不正解アイコン・矢印を `justify-between` と `gap-4` で横並びに配置し、重なりを解消
- お気に入りクリック時にアコーディオンが開閉しないよう `stopPropagation` を付与

## テスト内容

- `cd swa && npm run lint` — 成功
- `cd swa && npm run build` — 成功

## 関連Issue

- なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce464721-4584-4d72-bff4-d0cf43827488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce464721-4584-4d72-bff4-d0cf43827488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

