### PR TITLE
fix: 解説シートのレイアウト崩れと解説ボタンの色のデグレを修正

### DIFF
--- a/swa/src/components/OpenExplanationButton.tsx
+++ b/swa/src/components/OpenExplanationButton.tsx
@@ -1,7 +1,9 @@
 import { fetchAnswerExplanationAtom } from "@/lib/atoms";
 import { useAtomValue } from "jotai";
 import { Info } from "lucide-react";
-import { useId, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { Button } from "./Button";
 import ExplanationSheetContent from "./ExplanationSheetContent";
 import Tooltip from "./Tooltip";
 
@@ -11,7 +13,7 @@ import Tooltip from "./Tooltip";
  */
 export default function OpenExplanationButton() {
   const answerExplanation = useAtomValue(fetchAnswerExplanationAtom);
-  const drawerId = useId();
+  const [open, setOpen] = useState(false);
 
   // 回答・解説を生成していない場合、または生成中の場合は、解説表示ボタンを非活性とする
   // 回答済みの問題に遷移した場合は、explanationsが存在しなくてもanswerExplanationが存在すれば活性にする
@@ -21,31 +23,52 @@ export default function OpenExplanationButton() {
     [answerExplanation]
   );
 
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [close, open]);
+
   return (
-    <div className="drawer drawer-bottom">
-      <input id={drawerId} type="checkbox" className="drawer-toggle" />
-      <div className="drawer-content">
-        <Tooltip tip="解説表示" position="top">
-          <label
-            htmlFor={drawerId}
-            className={`btn btn-square ${isDisabledOpenExplanationButton ? "btn-disabled" : ""}`}
-            aria-disabled={isDisabledOpenExplanationButton}
-            onClick={(e) => {
-              if (isDisabledOpenExplanationButton) {
-                e.preventDefault();
-              }
-            }}
-          >
-            <Info />
-          </label>
-        </Tooltip>
-      </div>
-      <div className="drawer-side z-50">
-        <label htmlFor={drawerId} className="drawer-overlay" aria-label="閉じる" />
-        <div className="menu bg-base-100 text-base-content min-h-[20vh] max-h-[80vh] w-full p-4 overflow-y-auto rounded-t-2xl">
-          <ExplanationSheetContent />
-        </div>
-      </div>
-    </div>
+    <>
+      <Tooltip tip="解説表示" position="top">
+        <Button
+          size="icon"
+          disabled={isDisabledOpenExplanationButton}
+          onClick={() => setOpen(true)}
+        >
+          <Info />
+        </Button>
+      </Tooltip>
+      {open &&
+        createPortal(
+          <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true">
+            <button
+              type="button"
+              className="fixed inset-0 bg-black/80"
+              aria-label="閉じる"
+              onClick={close}
+            />
+            <div className="fixed inset-x-0 bottom-0 z-[101] max-h-[80vh] w-full min-h-[20vh] overflow-y-auto rounded-t-2xl border-t border-base-300 bg-base-100 p-4 text-base-content shadow-lg">
+              <ExplanationSheetContent />
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

daisyUI 移行時に `OpenExplanationButton` で導入したネスト型 `drawer` が、親要素（アイコンボタンコンテナ）の幅に拘束されて解説シートが細い帯状に表示されるデグレを修正しました。あわせて解説ボタンだけ `btn-primary` が付かず色が異なっていた問題を、他ボタンと同様の `Button` コンポーネント利用に戻して解消しています。

## 変更内容

- `OpenExplanationButton.tsx`
  - `label.btn` を `Button size="icon"`（`btn-primary`）に変更
  - daisyUI `drawer` を廃止し、`createPortal` で `document.body` 直下にボトムシートを描画
  - shadcn 時代と同様 `max-h-[80vh]`・画面幅いっぱい・下からのオーバーレイ表示
  - Escape / オーバーレイクリックで閉じる、表示中は `body` スクロールを抑制

## 原因

| 症状 | 原因 |
|------|------|
| 解説シートが右側の細い帯になる | `drawer` が `absolute` 配置の小さな親内で `drawer-side` を計算していたため |
| 解説ボタンだけ色が違う | 他ボタンは `Button`（`btn-primary`）なのに対し、解説のみ `label.btn`（デフォルト色）だったため |

## テスト内容

- `cd swa && npm run lint` — 成功
- `cd swa && npm run build` — 成功
- Playwright による画面キャプチャ（API モック + Vite dev、ダークモード）

## スクリーンショット（修正後）

### TestQuestionPage（解説シート表示）

[TestQuestionPage 解説シート](https://cursor.com/agents/bc-ce464721-4584-4d72-bff4-d0cf43827488/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdaisyui-verify%2Ftest-question-page-explanation-sheet.png)

### TestQuestionPage（回答送信後）

[TestQuestionPage 回答送信後](https://cursor.com/agents/bc-ce464721-4584-4d72-bff4-d0cf43827488/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdaisyui-verify%2Ftest-question-page-after-submit.png)

### TestResultPage

[TestResultPage](https://cursor.com/agents/bc-ce464721-4584-4d72-bff4-d0cf43827488/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdaisyui-verify%2Ftest-result-page.png)

## 関連Issue

- daisyUI 移行: #325

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce464721-4584-4d72-bff4-d0cf43827488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce464721-4584-4d72-bff4-d0cf43827488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

