### PR TITLE
feat: 回答生成にAzure OpenAIのWeb検索を追加

### DIFF
--- a/functions/src/post_answer.py
+++ b/functions/src/post_answer.py
@@ -70,7 +70,7 @@ def search_web_context(
     Web検索を用いて、正解判定の参考となる最新情報を取得する
 
     Azure OpenAIのResponses APIのweb_searchツールを使用し、問題文・選択肢に関連する
-    信頼できる最新の情報を取得する。Web検索が無効な場合や失敗した場合はNoneを返し、
+    信頼できる最新の情報を取得する。Web検索が失敗した場合はNoneを返し、
     呼び出し側はグラウンディングなしで回答生成を継続できる。
 
     Args:
@@ -78,12 +78,8 @@ def search_web_context(
         choices (list[str | None]): 選択肢のリスト(画像URLのみの場合はNone)
 
     Returns:
-        str | None: Web検索で得た参考情報(無効/取得できない場合はNone)
+        str | None: Web検索で得た参考情報(取得できない場合はNone)
     """
-
-    # WEB_SEARCH_ENABLEDがfalseの場合はWeb検索を実行しない
-    if os.environ.get("WEB_SEARCH_ENABLED", "true").lower() != "true":
-        return None
 
     # 問題文・選択肢からWeb検索用の入力テキストを作成(画像URLのみの選択肢は除外)
     question_text = "\n".join(subject for subject in subjects if subject)
@@ -356,7 +352,9 @@ def generate_correct_answers(
                 return CorrectAnswers(
                     correct_indexes=response.choices[0].message.parsed.correct_indexes,
                     explanations=response.choices[0].message.parsed.explanations,
-                    answer_key_point=response.choices[0].message.parsed.answer_key_point,
+                    answer_key_point=response.choices[
+                        0
+                    ].message.parsed.answer_key_point,
                 )
     except Exception:
         logging.warning(traceback.format_exc())

--- a/functions/src/post_answer.py
+++ b/functions/src/post_answer.py
@@ -26,6 +26,14 @@ MAX_RETRY_NUMBER: int = 5
 SYSTEM_PROMPT: str = (
     "You are a professional who provides correct explanations for candidates of the exam."
 )
+WEB_SEARCH_PROMPT: str = (
+    "You are researching to verify the correct answer to an IT certification exam question. "
+    "Search the web for authoritative and up-to-date information such as official product "
+    "documentation, vendor whitepapers, and reputable technical sources that are relevant to "
+    "the question and choices below. Summarize, in plain text, the key facts that help "
+    "determine which choice(s) are correct. Do not state the final answer; only provide the "
+    "supporting facts."
+)
 
 
 def validate_request(req: func.HttpRequest) -> str | None:
@@ -54,12 +62,72 @@ def validate_request(req: func.HttpRequest) -> str | None:
     return errors[0] if errors else None
 
 
-def create_chat_completions_messages(
+def search_web_context(
+    subjects: list[str],
+    choices: list[str | None],
+) -> str | None:
+    """
+    Web検索を用いて、正解判定の参考となる最新情報を取得する
+
+    Azure OpenAIのResponses APIのweb_searchツールを使用し、問題文・選択肢に関連する
+    信頼できる最新の情報を取得する。Web検索が無効な場合や失敗した場合はNoneを返し、
+    呼び出し側はグラウンディングなしで回答生成を継続できる。
+
+    Args:
+        subjects (list[str]): 問題文/画像URLのリスト
+        choices (list[str | None]): 選択肢のリスト(画像URLのみの場合はNone)
+
+    Returns:
+        str | None: Web検索で得た参考情報(無効/取得できない場合はNone)
+    """
+
+    # WEB_SEARCH_ENABLEDがfalseの場合はWeb検索を実行しない
+    if os.environ.get("WEB_SEARCH_ENABLED", "true").lower() != "true":
+        return None
+
+    # 問題文・選択肢からWeb検索用の入力テキストを作成(画像URLのみの選択肢は除外)
+    question_text = "\n".join(subject for subject in subjects if subject)
+    choices_text = "\n".join(
+        f"{chr(ord('A') + idx)}. {choice}"
+        for idx, choice in enumerate(choices)
+        if choice is not None
+    )
+    web_search_input = (
+        f"{WEB_SEARCH_PROMPT}\n\n"
+        f"# Question\n{question_text}\n\n"
+        f"# Choices\n{choices_text}"
+    )
+
+    try:
+        # web_searchツールを有効化してResponses APIを実行
+        response = AzureOpenAI(
+            api_key=os.environ["OPENAI_API_KEY"],
+            api_version=os.environ["OPENAI_API_VERSION"],
+            azure_deployment=os.environ["OPENAI_DEPLOYMENT_NAME"],
+            azure_endpoint=os.environ["OPENAI_ENDPOINT"],
+        ).responses.create(
+            model=os.environ["OPENAI_MODEL_NAME"],
+            tools=[{"type": "web_search"}],
+            input=web_search_input,
+        )
+        web_search_context = response.output_text
+        logging.info({"web_search_context": web_search_context})
+
+        # 空文字列の場合はグラウンディングなしとしてNoneを返す
+        return web_search_context if web_search_context else None
+    except Exception:
+        # Web検索に失敗しても回答生成は継続する(グラウンディングなしにフォールバック)
+        logging.warning(traceback.format_exc())
+        return None
+
+
+def create_chat_completions_messages(  # pylint: disable=R0913,R0917
     subjects: list[str],
     choices: list[str | None],
     answer_num: int,
     indicate_subject_img_idxes: list[int] | None,
     indicate_choice_imgs: list[str | None] | None,
+    web_search_context: str | None = None,
 ) -> Iterable[ChatCompletionMessageParam]:
     """
     Azure OpenAIのチャット補完に設定するmessagesを作成する
@@ -70,6 +138,7 @@ def create_chat_completions_messages(
         answer_num (int): 正解の選択肢の数
         indicate_subject_img_idxes (list[int] | None): subjectsで指定した画像URLのインデックスのリスト
         indicate_choice_imgs (list[str | None] | None): choicesの後に続ける画像URLのリスト(画像URLを続けない場合はNone)
+        web_search_context (str | None): Web検索で得た参考情報(ない場合はNone)
 
     Returns:
         Iterable[ChatCompletionMessageParam]: Azure OpenAIのチャット補完に設定するmessages
@@ -199,6 +268,16 @@ Important: Do not use any Markdown formatting (such as **, *, __, _, etc.) in th
             )
             user_content_text = ""
 
+    # Web検索で得た参考情報があればユーザープロンプトに追記
+    if web_search_context:
+        user_content_text += (
+            "\n# Reference Information from Web Search\n"
+            "The following information was retrieved from a web search to support your answer. "
+            "Use it as a supplementary reference, but rely on your own expertise to decide the "
+            "correct answer.\n"
+            f"{web_search_context}\n"
+        )
+
     # ユーザープロンプトのフッターを追記
     user_content_text += "---"
     user_content.append(
@@ -241,9 +320,17 @@ def generate_correct_answers(
         CorrectAnswers | None: 正解の選択肢のインデックス・正解/不正解の理由(生成できない場合はNone)
     """
 
+    # Web検索で正解判定の参考となる情報を取得し、プロンプトのグラウンディングに利用する
+    web_search_context: str | None = search_web_context(subjects, choices)
+
     # Azure OpenAIのチャット補完に設定するmessagesを作成
     messages: Iterable[ChatCompletionMessageParam] = create_chat_completions_messages(
-        subjects, choices, answer_num, indicate_subject_img_idxes, indicate_choice_imgs
+        subjects,
+        choices,
+        answer_num,
+        indicate_subject_img_idxes,
+        indicate_choice_imgs,
+        web_search_context,
     )
 
     try:

--- a/functions/tests/test_post_answer.py
+++ b/functions/tests/test_post_answer.py
@@ -77,7 +77,6 @@ class TestSearchWebContext(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "WEB_SEARCH_ENABLED": "true",
             "OPENAI_API_KEY": "test_api_key",
             "OPENAI_API_VERSION": "test_api_version",
             "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
@@ -100,9 +99,7 @@ class TestSearchWebContext(unittest.TestCase):
         result = search_web_context(subjects, choices)
 
         # Then: 取得したoutput_textが返り、web_searchツール付きで呼び出される
-        self.assertEqual(
-            result, "2 + 2 equals 4 according to authoritative sources."
-        )
+        self.assertEqual(result, "2 + 2 equals 4 according to authoritative sources.")
         mock_azure_openai.assert_called_once_with(
             api_key="test_api_key",
             api_version="test_api_version",
@@ -125,7 +122,6 @@ class TestSearchWebContext(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "WEB_SEARCH_ENABLED": "true",
             "OPENAI_API_KEY": "test_api_key",
             "OPENAI_API_VERSION": "test_api_version",
             "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
@@ -166,7 +162,6 @@ class TestSearchWebContext(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "WEB_SEARCH_ENABLED": "true",
             "OPENAI_API_KEY": "test_api_key",
             "OPENAI_API_VERSION": "test_api_version",
             "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
@@ -194,7 +189,6 @@ class TestSearchWebContext(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "WEB_SEARCH_ENABLED": "true",
             "OPENAI_API_KEY": "test_api_key",
             "OPENAI_API_VERSION": "test_api_version",
             "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
@@ -216,19 +210,6 @@ class TestSearchWebContext(unittest.TestCase):
         # Then: Noneが返り、例外がwarningログに記録される
         self.assertIsNone(result)
         mock_logging.warning.assert_called_once()
-
-    @patch("src.post_answer.AzureOpenAI")
-    @patch.dict(os.environ, {"WEB_SEARCH_ENABLED": "false"})
-    def test_search_web_context_disabled(self, mock_azure_openai):
-        """WEB_SEARCH_ENABLEDがfalseの場合にWeb検索を実行しないテスト"""
-
-        # Given: WEB_SEARCH_ENABLEDがfalse
-        # When: Web検索を実行する
-        result = search_web_context(["What is 2 + 2?"], ["3", "4", "5"])
-
-        # Then: Noneが返り、Azure OpenAIは呼び出されない
-        self.assertIsNone(result)
-        mock_azure_openai.assert_not_called()
 
 
 class TestCreateChatCompletionsMessages(unittest.TestCase):

--- a/functions/tests/test_post_answer.py
+++ b/functions/tests/test_post_answer.py
@@ -1,5 +1,7 @@
 """[POST] /tests/{testId}/answers/{questionNumber} のテスト"""
 
+# pylint: disable=too-many-lines
+
 import json
 import os
 import unittest
@@ -10,10 +12,12 @@ from azure.cosmos.exceptions import CosmosResourceNotFoundError
 from src.post_answer import (
     MAX_RETRY_NUMBER,
     SYSTEM_PROMPT,
+    WEB_SEARCH_PROMPT,
     create_chat_completions_messages,
     generate_correct_answers,
     post_answer,
     queue_message_answer,
+    search_web_context,
     validate_request,
 )
 from type.cosmos import Question
@@ -63,6 +67,168 @@ class TestValidateRequest(unittest.TestCase):
         result = validate_request(req)
 
         self.assertEqual(result, "Invalid questionNumber: a")
+
+
+class TestSearchWebContext(unittest.TestCase):
+    """search_web_context関数のテストケース"""
+
+    @patch("src.post_answer.AzureOpenAI")
+    @patch("src.post_answer.logging")
+    @patch.dict(
+        os.environ,
+        {
+            "WEB_SEARCH_ENABLED": "true",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_API_VERSION": "test_api_version",
+            "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
+            "OPENAI_ENDPOINT": "test_endpoint",
+            "OPENAI_MODEL_NAME": "test_model_name",
+        },
+    )
+    def test_search_web_context_success(self, mock_logging, mock_azure_openai):
+        """Web検索で参考情報を取得できる場合のテスト"""
+
+        # Given: Responses APIがoutput_textを返すようにモックする
+        mock_response = MagicMock()
+        mock_response.output_text = "2 + 2 equals 4 according to authoritative sources."
+        mock_azure_openai.return_value.responses.create.return_value = mock_response
+
+        subjects = ["What is 2 + 2?"]
+        choices = ["3", "4", "5"]
+
+        # When: Web検索を実行する
+        result = search_web_context(subjects, choices)
+
+        # Then: 取得したoutput_textが返り、web_searchツール付きで呼び出される
+        self.assertEqual(
+            result, "2 + 2 equals 4 according to authoritative sources."
+        )
+        mock_azure_openai.assert_called_once_with(
+            api_key="test_api_key",
+            api_version="test_api_version",
+            azure_deployment="test_deployment_name",
+            azure_endpoint="test_endpoint",
+        )
+        mock_azure_openai.return_value.responses.create.assert_called_once_with(
+            model="test_model_name",
+            tools=[{"type": "web_search"}],
+            input=(
+                f"{WEB_SEARCH_PROMPT}\n\n"
+                "# Question\nWhat is 2 + 2?\n\n"
+                "# Choices\nA. 3\nB. 4\nC. 5"
+            ),
+        )
+        mock_logging.warning.assert_not_called()
+
+    @patch("src.post_answer.AzureOpenAI")
+    @patch("src.post_answer.logging")
+    @patch.dict(
+        os.environ,
+        {
+            "WEB_SEARCH_ENABLED": "true",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_API_VERSION": "test_api_version",
+            "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
+            "OPENAI_ENDPOINT": "test_endpoint",
+            "OPENAI_MODEL_NAME": "test_model_name",
+        },
+    )
+    def test_search_web_context_skip_image_only_choices(
+        self, mock_logging, mock_azure_openai
+    ):
+        """画像URLのみの選択肢(None)が検索クエリから除外されるテスト"""
+
+        # Given: 一部の選択肢が画像URLのみ(None)
+        mock_response = MagicMock()
+        mock_response.output_text = "context"
+        mock_azure_openai.return_value.responses.create.return_value = mock_response
+
+        subjects = ["What is shown?"]
+        choices = ["3", None, "5"]
+
+        # When: Web検索を実行する
+        search_web_context(subjects, choices)
+
+        # Then: Noneの選択肢は除外され、テキストの選択肢のみクエリに含まれる
+        mock_azure_openai.return_value.responses.create.assert_called_once_with(
+            model="test_model_name",
+            tools=[{"type": "web_search"}],
+            input=(
+                f"{WEB_SEARCH_PROMPT}\n\n"
+                "# Question\nWhat is shown?\n\n"
+                "# Choices\nA. 3\nC. 5"
+            ),
+        )
+        mock_logging.warning.assert_not_called()
+
+    @patch("src.post_answer.AzureOpenAI")
+    @patch("src.post_answer.logging")
+    @patch.dict(
+        os.environ,
+        {
+            "WEB_SEARCH_ENABLED": "true",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_API_VERSION": "test_api_version",
+            "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
+            "OPENAI_ENDPOINT": "test_endpoint",
+            "OPENAI_MODEL_NAME": "test_model_name",
+        },
+    )
+    def test_search_web_context_empty_output(self, mock_logging, mock_azure_openai):
+        """Web検索の結果が空文字列の場合にNoneを返すテスト"""
+
+        # Given: Responses APIが空のoutput_textを返す
+        mock_response = MagicMock()
+        mock_response.output_text = ""
+        mock_azure_openai.return_value.responses.create.return_value = mock_response
+
+        # When: Web検索を実行する
+        result = search_web_context(["What is 2 + 2?"], ["3", "4", "5"])
+
+        # Then: Noneが返る
+        self.assertIsNone(result)
+        mock_logging.warning.assert_not_called()
+
+    @patch("src.post_answer.AzureOpenAI")
+    @patch("src.post_answer.logging")
+    @patch.dict(
+        os.environ,
+        {
+            "WEB_SEARCH_ENABLED": "true",
+            "OPENAI_API_KEY": "test_api_key",
+            "OPENAI_API_VERSION": "test_api_version",
+            "OPENAI_DEPLOYMENT_NAME": "test_deployment_name",
+            "OPENAI_ENDPOINT": "test_endpoint",
+            "OPENAI_MODEL_NAME": "test_model_name",
+        },
+    )
+    def test_search_web_context_raise_error(self, mock_logging, mock_azure_openai):
+        """Web検索で例外が発生した場合にNoneを返すテスト"""
+
+        # Given: Responses APIが例外を送出する
+        mock_azure_openai.return_value.responses.create.side_effect = Exception(
+            "Web Search Error"
+        )
+
+        # When: Web検索を実行する
+        result = search_web_context(["What is 2 + 2?"], ["3", "4", "5"])
+
+        # Then: Noneが返り、例外がwarningログに記録される
+        self.assertIsNone(result)
+        mock_logging.warning.assert_called_once()
+
+    @patch("src.post_answer.AzureOpenAI")
+    @patch.dict(os.environ, {"WEB_SEARCH_ENABLED": "false"})
+    def test_search_web_context_disabled(self, mock_azure_openai):
+        """WEB_SEARCH_ENABLEDがfalseの場合にWeb検索を実行しないテスト"""
+
+        # Given: WEB_SEARCH_ENABLEDがfalse
+        # When: Web検索を実行する
+        result = search_web_context(["What is 2 + 2?"], ["3", "4", "5"])
+
+        # Then: Noneが返り、Azure OpenAIは呼び出されない
+        self.assertIsNone(result)
+        mock_azure_openai.assert_not_called()
 
 
 class TestCreateChatCompletionsMessages(unittest.TestCase):
@@ -180,6 +346,81 @@ class TestCreateChatCompletionsMessages(unittest.TestCase):
                 },
             ],
         )
+
+    def test_create_chat_completions_messages_web_search_context(self):
+        """Web検索の参考情報が渡された場合のテスト"""
+
+        # Given: 問題文・選択肢・Web検索の参考情報
+        subjects = ["What is 2 + 2?"]
+        choices = ["3", "4", "5"]
+        answer_num = 1
+        web_search_context = "According to a reliable source, 2 + 2 equals 4."
+
+        # When: Web検索の参考情報を渡してmessagesを作成する
+        messages = create_chat_completions_messages(
+            subjects,
+            choices,
+            answer_num,
+            None,
+            None,
+            web_search_context,
+        )
+
+        # Then: 参考情報セクションがフッターの直前に挿入される
+        self.assertEqual(
+            messages,
+            [
+                {
+                    "role": "developer",
+                    "content": SYSTEM_PROMPT,
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                self.USER_CONTENT_TEXT_HEADER.format(
+                                    answer_num=answer_num
+                                )
+                                + "What is 2 + 2?\n\n"
+                                + "A. 3\n"
+                                + "B. 4\n"
+                                + "C. 5\n"
+                                + "\n# Reference Information from Web Search\n"
+                                + "The following information was retrieved from a web "
+                                "search to support your answer. "
+                                "Use it as a supplementary reference, but rely on your "
+                                "own expertise to decide the correct answer.\n"
+                                + f"{web_search_context}\n"
+                                + self.USER_CONTENT_TEXT_FOOTER
+                            ),
+                        }
+                    ],
+                },
+            ],
+        )
+
+    def test_create_chat_completions_messages_no_web_search_context(self):
+        """Web検索の参考情報が渡されない場合に参考情報セクションが挿入されないテスト"""
+
+        # Given: 問題文・選択肢のみ(Web検索の参考情報なし)
+        subjects = ["What is 2 + 2?"]
+        choices = ["3", "4", "5"]
+        answer_num = 1
+
+        # When: web_search_contextを省略してmessagesを作成する
+        messages = create_chat_completions_messages(
+            subjects,
+            choices,
+            answer_num,
+            None,
+            None,
+        )
+
+        # Then: 参考情報セクションは挿入されない
+        user_text = messages[1]["content"][0]["text"]
+        self.assertNotIn("# Reference Information from Web Search", user_text)
 
     def test_create_chat_completions_messages_subject_images(self):
         """問題文に画像URLが含まれる場合のテスト"""
@@ -381,6 +622,7 @@ class TestCreateChatCompletionsMessages(unittest.TestCase):
 class TestGenerateCorrectAnswers(unittest.TestCase):
     """generate_correct_answers関数のテストケース"""
 
+    @patch("src.post_answer.search_web_context")
     @patch("src.post_answer.AzureOpenAI")
     @patch("src.post_answer.create_chat_completions_messages")
     @patch("src.post_answer.logging")
@@ -399,9 +641,12 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         mock_logging,
         mock_create_chat_completions_messages,
         mock_azure_openai,
+        mock_search_web_context,
     ):
         """リトライせずに、正解の選択肢のインデックス・正解/不正解の理由を生成するテスト"""
 
+        # Given: Web検索の参考情報とStructured Outputのレスポンスをモックする
+        mock_search_web_context.return_value = "web search context"
         mock_messages = [
             {"role": "developer", "content": SYSTEM_PROMPT},
             {
@@ -430,8 +675,10 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         subjects = ["What is 2 + 2?"]
         choices = ["3", "4", "5"]
 
+        # When: 正解生成を実行する
         correct_answers = generate_correct_answers(subjects, choices, 1, None, None)
 
+        # Then: 正解・解説が返却され、Web検索の参考情報がプロンプトに渡される
         self.assertEqual(correct_answers["correct_indexes"], [2])
         self.assertEqual(
             correct_answers["explanations"],
@@ -441,8 +688,9 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
             correct_answers["answer_key_point"],
             "Basic arithmetic: 2 + 2 equals 4.",
         )
+        mock_search_web_context.assert_called_once_with(subjects, choices)
         mock_create_chat_completions_messages.assert_called_once_with(
-            subjects, choices, 1, None, None
+            subjects, choices, 1, None, None, "web search context"
         )
         mock_azure_openai.assert_called_once_with(
             api_key="test_api_key",
@@ -463,6 +711,7 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         )
         mock_logging.warning.assert_not_called()
 
+    @patch("src.post_answer.search_web_context")
     @patch("src.post_answer.AzureOpenAI")
     @patch("src.post_answer.create_chat_completions_messages")
     @patch("src.post_answer.logging")
@@ -481,9 +730,12 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         mock_logging,
         mock_create_chat_completions_messages,
         mock_azure_openai,
+        mock_search_web_context,
     ):
         """MAX_RETRY_NUMBER回リトライしても、正解の選択肢のインデックス・正解/不正解の理由が生成できない場合のテスト"""
 
+        # Given: Web検索が参考情報を返さず、Structured Outputのparseが常にNoneを返す
+        mock_search_web_context.return_value = None
         mock_messages = [
             {"role": "developer", "content": SYSTEM_PROMPT},
             {
@@ -506,11 +758,14 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         subjects = ["What is 2 + 2?"]
         choices = ["3", "4", "5"]
 
+        # When: 正解生成を実行する
         correct_answers = generate_correct_answers(subjects, choices, 1, None, None)
 
+        # Then: Noneが返り、Web検索の参考情報(None)がプロンプトに渡される
         self.assertIsNone(correct_answers)
+        mock_search_web_context.assert_called_once_with(subjects, choices)
         mock_create_chat_completions_messages.assert_called_once_with(
-            subjects, choices, 1, None, None
+            subjects, choices, 1, None, None, None
         )
         mock_logging.info.assert_has_calls(
             [
@@ -520,6 +775,7 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         )
         mock_logging.warning.assert_not_called()
 
+    @patch("src.post_answer.search_web_context")
     @patch("src.post_answer.AzureOpenAI")
     @patch("src.post_answer.create_chat_completions_messages")
     @patch("src.post_answer.logging")
@@ -538,9 +794,12 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         mock_logging,
         mock_create_chat_completions_messages,
         mock_azure_openai,
+        mock_search_web_context,
     ):
         """正解の選択肢のインデックス・正解/不正解の理由の生成でエラーが発生した場合のテスト"""
 
+        # Given: Web検索が参考情報を返さず、Structured Outputのparseで例外が発生する
+        mock_search_web_context.return_value = None
         mock_messages = [
             {"role": "developer", "content": SYSTEM_PROMPT},
             {
@@ -561,11 +820,14 @@ class TestGenerateCorrectAnswers(unittest.TestCase):
         subjects = ["What is 2 + 2?"]
         choices = ["3", "4", "5"]
 
+        # When: 正解生成を実行する
         correct_answers = generate_correct_answers(subjects, choices, 1, None, None)
 
+        # Then: Noneが返り、例外がwarningログに記録される
         self.assertIsNone(correct_answers)
+        mock_search_web_context.assert_called_once_with(subjects, choices)
         mock_create_chat_completions_messages.assert_called_once_with(
-            subjects, choices, 1, None, None
+            subjects, choices, 1, None, None, None
         )
         mock_logging.info.assert_called_once_with({"retry_number": 0})
         mock_logging.warning.assert_called_once()

--- a/localenvironment.md
+++ b/localenvironment.md
@@ -44,7 +44,6 @@ Azure 環境構築後に、以下のサーバーをすべて起動すると、�
        "OPENAI_DEPLOYMENT_NAME": "(Azure OpenAIのデプロイ名)",
        "OPENAI_ENDPOINT": "(Azure OpenAIのエンドポイント)",
        "OPENAI_MODEL_NAME": "(Azure OpenAIのモデル名)",
-       "WEB_SEARCH_ENABLED": "true",
        "PYTHON_PATH": "./venv/bin/python",
        "TRANSLATOR_KEY": "(TranslatorのAPIキー)"
      },
@@ -55,6 +54,7 @@ Azure 環境構築後に、以下のサーバーをすべて起動すると、�
      "ConnectionStrings": {}
    }
    ```
+
    - CORS は任意のオリジンを許可するように設定しているため、特定のオリジンのみ許可したい場合は`Host` > `CORS`にそのオリジンを設定すること。
 4. ターミナルを起動して以下のコマンドを実行し、Cosmos DB、Blob/Queue/Table ストレージをすべて起動する。実行したターミナルはそのまま放置する。
    ```bash
@@ -81,11 +81,14 @@ Azure 環境構築後に、以下のサーバーをすべて起動すると、�
    func start --verbose
    ```
 8. 7 とは別のターミナルで以下のコマンドを実行し、6 で作成した仮想環境の有効後、起動した Cosmos DB サーバーに対し、インポートデータファイルからインポートする。実行したターミナルは閉じる。
+
    ```bash
    ./venv/Scripts/activate
    python functions/import_local.py
    ```
+
    - タイムアウトなどで失敗した場合、もう一度実行し直すこと。
+
 9. 以下を記述したファイル`.env`を swa ディレクトリ配下に保存する。
    ```
    VITE_API_URI="http://localhost:9229"

--- a/localenvironment.md
+++ b/localenvironment.md
@@ -44,6 +44,7 @@ Azure 環境構築後に、以下のサーバーをすべて起動すると、�
        "OPENAI_DEPLOYMENT_NAME": "(Azure OpenAIのデプロイ名)",
        "OPENAI_ENDPOINT": "(Azure OpenAIのエンドポイント)",
        "OPENAI_MODEL_NAME": "(Azure OpenAIのモデル名)",
+       "WEB_SEARCH_ENABLED": "true",
        "PYTHON_PATH": "./venv/bin/python",
        "TRANSLATOR_KEY": "(TranslatorのAPIキー)"
      },

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ azure-functions==1.24.0
 azure-identity==1.25.3
 azure-storage-queue==12.12.0
 coverage==7.14.0
-openai==1.58.1
+openai==1.109.1
 pydantic==2.13.4
 pylint==4.0.5
 requests==2.34.2

--- a/resources/base.bicep
+++ b/resources/base.bicep
@@ -477,6 +477,10 @@ resource functions 'Microsoft.Web/sites@2023-12-01' = {
           value: openAIModelName
         }
         {
+          name: 'WEB_SEARCH_ENABLED'
+          value: 'true'
+        }
+        {
           name: 'WEBSITE_ENABLE_SYNC_UPDATE_SITE'
           value: 'true'
         }

--- a/resources/base.bicep
+++ b/resources/base.bicep
@@ -477,10 +477,6 @@ resource functions 'Microsoft.Web/sites@2023-12-01' = {
           value: openAIModelName
         }
         {
-          name: 'WEB_SEARCH_ENABLED'
-          value: 'true'
-        }
-        {
           name: 'WEBSITE_ENABLE_SYNC_UPDATE_SITE'
           value: 'true'
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`[POST] /tests/{testId}/answers/{questionNumber}` で正解の選択肢・解説文を生成する際、これまでは Azure OpenAI の LLM に単純に invoke するのみだった。本 PR では [Azure OpenAI の Web 検索機能](https://learn.microsoft.com/ja-jp/azure/foundry/openai/how-to/web-search?tabs=python) を組み合わせ、Web 検索で取得した最新かつ信頼できる情報をグラウンディングとして利用することで、正解生成の精度向上を図る。

## 変更内容

- `functions/src/post_answer.py`
  - `search_web_context` を新規追加。Azure OpenAI の Responses API の `web_search` ツールを用いて、問題文・選択肢に関連する信頼できる情報を取得する。
  - `create_chat_completions_messages` に `web_search_context` 引数を追加し、取得した参考情報を「# Reference Information from Web Search」セクションとしてユーザープロンプトのフッター直前に注入する。
  - `generate_correct_answers` を「Web 検索 → Structured Output で正解生成」の 2 段階に変更。
- `requirements.txt`: Responses API 利用のため `openai` を `1.58.1` → `1.109.1` に更新。
- `localenvironment.md` / `resources/base.bicep`: `WEB_SEARCH_ENABLED` 設定を追記。
- `functions/tests/test_post_answer.py`: 新機能のテストを追加・既存テストを更新。

## 技術的な詳細

- Web 検索は Azure OpenAI の Responses API (`responses.create` + `tools=[{"type": "web_search"}]`) でのみ利用可能なため、既存の `beta.chat.completions.parse` による Structured Output 生成フローは維持しつつ、その前段に Web 検索ステップを追加する 2 段階構成とした。これにより既存の構造化出力・リトライ・マルチモーダル対応のロジックへの影響を最小化している。
- 堅牢性のため、Web 検索が無効・失敗した場合は `None` にフォールバックし、グラウンディングなしで従来どおり回答生成を継続する（Web 検索の失敗がエンドポイント全体の失敗につながらない）。
- `WEB_SEARCH_ENABLED` 環境変数（既定 `true`）で Web 検索の ON/OFF を制御可能。`false` の場合は Web 検索を実行しない。
- 画像 URL のみの選択肢（`None`）は Web 検索クエリから除外する。
- 本番では Responses API の `web_search` ツールがサブスクリプションで有効化されている必要がある。

## テスト内容

- `cd functions && coverage run -m unittest discover -s tests && coverage report -m`
  - 全 195 件パス。`src/post_answer.py` のカバレッジは 100%。
  - 追加テスト観点: Web 検索成功 / 画像のみ選択肢の除外 / 空応答時の `None` / 例外時のフォールバック / `WEB_SEARCH_ENABLED=false` での無効化 / プロンプトへの参考情報注入有無 / 正解生成フローへの統合。
- `pylint functions/**/*.py` → 10.00/10。
- 統合スモークテスト: openai SDK 1.109.1 の `AzureOpenAI(...).responses.create(tools=[{"type":"web_search"}], input=...)` がパラメータ形状を受理し、ネットワーク層まで到達することを確認（`APIConnectionError`）。あわせて `search_web_context` が接続失敗時に `None` を返すフォールバックも確認済み。

> Web 検索の実 API を叩く E2E テストは、`web_search` ツールが有効化された Azure OpenAI のサブスクリプション認証情報が必要なため本環境では実施不可。上記の単体テスト・統合スモークテストで代替検証している。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4088b22f-e9a3-4f75-8198-01bc472754b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4088b22f-e9a3-4f75-8198-01bc472754b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

