### PR TITLE
fix: connect-apim-2-functions の listKeys 呼び出しを修正

### DIFF
--- a/resources/connect-apim-2-functions.bicep
+++ b/resources/connect-apim-2-functions.bicep
@@ -11,6 +11,11 @@ var vaultSecretNames = {
   functionsDefaultHostKey: 'functions-default-host-key'
 }
 
+// Functions
+resource functions 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: functionsName
+}
+
 // Key Vault
 resource vaultSecretsFunctionsDefaultHostKey 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
   name: '${vaultName}/${vaultSecretNames.functionsDefaultHostKey}'
@@ -18,10 +23,7 @@ resource vaultSecretsFunctionsDefaultHostKey 'Microsoft.KeyVault/vaults/secrets@
     attributes: {
       enabled: true
     }
-    value: listKeys(
-      resourceId('Microsoft.Web/sites/host', functionsName, 'default'),
-      '2022-09-01'
-    ).functionKeys.default
+    value: listKeys('${functions.id}/host/default', '2023-12-01').functionKeys.default
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Create Azure Resources ワークフローの `connect-apim-2-functions` ジョブで発生していた Bicep リンター警告（`use-recognized-resource-type`）を解消するため、`listKeys` の呼び出し方法を修正しました。

## 変更内容

- `connect-apim-2-functions.bicep` に既存の Functions App リソース参照（`Microsoft.Web/sites@2023-12-01` existing）を追加
- `listKeys(resourceId('Microsoft.Web/sites/host', ...), ...)` を `listKeys('${functions.id}/host/default', '2023-12-01')` に変更
- 同一リポジトリ内の `event-grid-subscription.bicep` と同じパターンに統一

## 技術的な詳細

Bicep 0.43 以降では、`listKeys` に `resourceId('Microsoft.Web/sites/host', ...)` を渡すと、リソース型 `Microsoft.Web/sites/host` が認識されないというリンター警告が出力されます。CI の `az bicep upgrade` により最新版が使われるため、この警告がデプロイ失敗の原因になっていました。

Functions のホストキー取得は、親サイトのリソース ID に `/host/default` を付与した文字列形式で指定するのが推奨パターンです。

## テスト内容

- Bicep CLI 0.43.8 で `bicep build` / `bicep lint` を実行し、警告が出力されないことを確認

```bash
bicep build ./resources/connect-apim-2-functions.bicep
bicep lint ./resources/connect-apim-2-functions.bicep
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbf2e9f9-27a7-4392-af78-45be716e0959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbf2e9f9-27a7-4392-af78-45be716e0959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

