### PR TITLE
fix: TestQuestionResizableHandle のスクロールとタッチ判定を復元

### DIFF
--- a/swa/src/components/TestQuestionResizableHandle.tsx
+++ b/swa/src/components/TestQuestionResizableHandle.tsx
@@ -1,5 +1,13 @@
 import { GripVertical } from "lucide-react";
+import { useCallback } from "react";
 
+import { useTestQuestionResizeHandleTouch } from "@/hooks/useTestQuestionResizeHandleTouch";
+import {
+  getAdjacentScrollContainers,
+  scrollContainersByDelta,
+  TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX,
+  TOUCH_HIT_AREA_MARGINS,
+} from "@/lib/testQuestionScroll";
 import { cn } from "@/lib/utils";
 import { PanelResizeHandle } from "react-resizable-panels";
 
@@ -9,19 +17,54 @@ const TestQuestionResizableHandle = ({
   ...props
 }: React.ComponentProps<typeof PanelResizeHandle> & {
   withHandle?: boolean;
-}) => (
-  <PanelResizeHandle
-    className={cn(
-      "relative flex w-px items-center justify-center bg-base-300 hover:bg-sky-500 transition-colors duration-200 after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
-      className
-    )}
-    {...props}
-  >
-    {withHandle && (
-      <div className="z-20 flex h-4 w-3 items-center justify-center rounded-sm border border-base-300 bg-base-300 hover:bg-sky-500 transition-colors duration-200">
-        <GripVertical className="h-2.5 w-2.5" />
-      </div>
-    )}
-  </PanelResizeHandle>
-);
+}) => {
+  const resizeHandleInstanceId = useTestQuestionResizeHandleTouch();
+
+  const handleWheel = useCallback<
+    NonNullable<React.ComponentProps<typeof PanelResizeHandle>["onWheel"]>
+  >(
+    (event) => {
+      const handleElement = document.getElementById(
+        `${TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX}-${resizeHandleInstanceId}`
+      );
+      if (!handleElement) {
+        return;
+      }
+
+      const containers = getAdjacentScrollContainers(handleElement);
+      if (containers.length === 0) {
+        return;
+      }
+
+      if (scrollContainersByDelta(containers, event.deltaY)) {
+        event.preventDefault();
+      }
+    },
+    [resizeHandleInstanceId]
+  );
+
+  return (
+    <PanelResizeHandle
+      id={`${TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX}-${resizeHandleInstanceId}`}
+      className={cn(
+        "relative flex w-px items-center justify-center bg-base-300 hover:bg-sky-500 transition-colors duration-200 after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        className
+      )}
+      hitAreaMargins={TOUCH_HIT_AREA_MARGINS}
+      onWheel={handleWheel}
+      style={{ touchAction: "pan-y" }}
+      {...props}
+    >
+      {withHandle && (
+        <div
+          data-resize-grip
+          className="z-20 flex h-4 w-3 items-center justify-center rounded-sm border border-base-300 bg-base-300 hover:bg-sky-500 transition-colors duration-200"
+        >
+          <GripVertical className="h-2.5 w-2.5" />
+        </div>
+      )}
+    </PanelResizeHandle>
+  );
+};
+
 export default TestQuestionResizableHandle;

--- a/swa/src/components/TestQuestionResizableHandle.tsx
+++ b/swa/src/components/TestQuestionResizableHandle.tsx
@@ -7,7 +7,7 @@ import {
   scrollContainersByDelta,
   TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX,
   TOUCH_HIT_AREA_MARGINS,
-} from "@/lib/testQuestionScroll";
+} from "@/lib/scroll";
 import { cn } from "@/lib/utils";
 import { PanelResizeHandle } from "react-resizable-panels";
 

--- a/swa/src/hooks/useTestQuestionResizeHandleTouch.ts
+++ b/swa/src/hooks/useTestQuestionResizeHandleTouch.ts
@@ -1,0 +1,131 @@
+import {
+  getAdjacentScrollContainers,
+  scrollContainersByDelta,
+  TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX,
+  TOUCH_SCROLL_DOMINANCE_RATIO,
+  TOUCH_SCROLL_THRESHOLD_PX,
+} from "@/lib/testQuestionScroll";
+import { useEffect, useId } from "react";
+
+type TouchGestureState = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  lastY: number;
+  isScrollGesture: boolean;
+};
+
+export function useTestQuestionResizeHandleTouch() {
+  const resizeHandleInstanceId = useId();
+
+  useEffect(() => {
+    const handleElement = document.getElementById(
+      `${TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX}-${resizeHandleInstanceId}`
+    );
+    if (!handleElement) {
+      return;
+    }
+
+    let touchGesture: TouchGestureState | null = null;
+
+    const resetTouchGesture = () => {
+      touchGesture = null;
+    };
+
+    const isResizeGripTarget = (target: EventTarget | null) => {
+      if (!(target instanceof Node)) {
+        return false;
+      }
+      const grip = handleElement.querySelector("[data-resize-grip]");
+      return grip?.contains(target) ?? false;
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (event.pointerType !== "touch") {
+        return;
+      }
+
+      if (
+        !(event.target instanceof Node) ||
+        !handleElement.contains(event.target)
+      ) {
+        return;
+      }
+
+      if (isResizeGripTarget(event.target)) {
+        resetTouchGesture();
+        return;
+      }
+
+      event.stopImmediatePropagation();
+
+      touchGesture = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        lastY: event.clientY,
+        isScrollGesture: false,
+      };
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!touchGesture || touchGesture.pointerId !== event.pointerId) {
+        return;
+      }
+
+      const deltaY = event.clientY - touchGesture.startY;
+      const deltaX = event.clientX - touchGesture.startX;
+
+      if (!touchGesture.isScrollGesture) {
+        if (
+          Math.abs(deltaY) < TOUCH_SCROLL_THRESHOLD_PX &&
+          Math.abs(deltaX) < TOUCH_SCROLL_THRESHOLD_PX
+        ) {
+          return;
+        }
+
+        if (Math.abs(deltaY) > Math.abs(deltaX) * TOUCH_SCROLL_DOMINANCE_RATIO) {
+          touchGesture.isScrollGesture = true;
+        } else {
+          resetTouchGesture();
+          return;
+        }
+      }
+
+      const step = event.clientY - touchGesture.lastY;
+      touchGesture.lastY = event.clientY;
+
+      const containers = getAdjacentScrollContainers(handleElement);
+      if (scrollContainersByDelta(containers, step)) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    };
+
+    const onPointerEnd = (event: PointerEvent) => {
+      if (touchGesture?.pointerId === event.pointerId) {
+        resetTouchGesture();
+      }
+    };
+
+    window.addEventListener("pointerdown", onPointerDown, { capture: true });
+    window.addEventListener("pointermove", onPointerMove, { capture: true });
+    window.addEventListener("pointerup", onPointerEnd, { capture: true });
+    window.addEventListener("pointercancel", onPointerEnd, { capture: true });
+
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown, {
+        capture: true,
+      });
+      window.removeEventListener("pointermove", onPointerMove, {
+        capture: true,
+      });
+      window.removeEventListener("pointerup", onPointerEnd, { capture: true });
+      window.removeEventListener("pointercancel", onPointerEnd, {
+        capture: true,
+      });
+    };
+  }, [resizeHandleInstanceId]);
+
+  return resizeHandleInstanceId;
+}

--- a/swa/src/hooks/useTestQuestionResizeHandleTouch.ts
+++ b/swa/src/hooks/useTestQuestionResizeHandleTouch.ts
@@ -4,9 +4,23 @@ import {
   TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX,
   TOUCH_SCROLL_DOMINANCE_RATIO,
   TOUCH_SCROLL_THRESHOLD_PX,
-} from "@/lib/testQuestionScroll";
+} from "@/lib/scroll";
 import { useEffect, useId } from "react";
 
+/**
+ * TestQuestionResizableHandle 向けのタッチ操作フック。
+ *
+ * タッチ端末では PanelResizeHandle が pointer イベントを先に捕捉し、
+ * 縦スワイプがリサイズと誤判定されやすい。本フックは次を行う:
+ *
+ * - グリップ（data-resize-grip）上のタッチ → リサイズライブラリに任せる
+ * - ハンドルバー上のタッチ → 縦方向の移動を緩くスクロールとみなし、上下パネルをスクロール
+ *
+ * capture フェーズで pointer イベントを監視し、スクロール時は
+ * stopImmediatePropagation でリサイズ開始を抑止する。
+ *
+ * @returns PanelResizeHandle に付与する一意の id サフィックス（useId）
+ */
 type TouchGestureState = {
   pointerId: number;
   startX: number;
@@ -52,11 +66,13 @@ export function useTestQuestionResizeHandleTouch() {
         return;
       }
 
+      // 中央グリップのみパネルリサイズ。バー部分は後続 move でスクロール判定する
       if (isResizeGripTarget(event.target)) {
         resetTouchGesture();
         return;
       }
 
+      // react-resizable-panels の pointerdown（capture）より先に処理し、リサイズ開始を抑止
       event.stopImmediatePropagation();
 
       touchGesture = {
@@ -77,6 +93,7 @@ export function useTestQuestionResizeHandleTouch() {
       const deltaX = event.clientX - touchGesture.startX;
 
       if (!touchGesture.isScrollGesture) {
+        // 微小な揺れは無視
         if (
           Math.abs(deltaY) < TOUCH_SCROLL_THRESHOLD_PX &&
           Math.abs(deltaX) < TOUCH_SCROLL_THRESHOLD_PX
@@ -84,6 +101,7 @@ export function useTestQuestionResizeHandleTouch() {
           return;
         }
 
+        // 縦成分が横より十分大きい場合のみスクロール gesture とみなす（緩い判定）
         if (Math.abs(deltaY) > Math.abs(deltaX) * TOUCH_SCROLL_DOMINANCE_RATIO) {
           touchGesture.isScrollGesture = true;
         } else {

--- a/swa/src/lib/scroll.ts
+++ b/swa/src/lib/scroll.ts
@@ -1,6 +1,17 @@
+/**
+ * TestQuestionPage のリサイズハンドル向けスクロール補助ユーティリティ。
+ *
+ * react-resizable-panels の PanelResizeHandle はホイール／タッチを奪いやすく、
+ * ハンドル上から上下パネル（問題文・選択肢）をスクロールできなくなる。
+ * 本モジュールは、ハンドル操作を隣接パネル内のスクロールコンテナへ転送するための
+ * セレクタ・定数・関数を提供する。
+ */
+
+/** TestQuestionPage 内でスクロール対象となる要素を示す data 属性 */
 export const TEST_QUESTION_SCROLL_CONTAINER_SELECTOR =
   "[data-test-question-scroll-container]";
 
+/** TestQuestionResizableHandle の DOM id プレフィックス（useId と組み合わせて使用） */
 export const TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX =
   "test-question-resize-handle";
 
@@ -10,9 +21,13 @@ export const TOUCH_SCROLL_THRESHOLD_PX = 10;
 /** タッチ操作時に縦スクロールとみなす縦横比（大きいほどスクロール判定が緩い） */
 export const TOUCH_SCROLL_DOMINANCE_RATIO = 1.2;
 
-/** タッチ向け hit area（既定 coarse: 15 より広い） */
+/** タッチ向け hit area（react-resizable-panels 既定 coarse: 15 より広い） */
 export const TOUCH_HIT_AREA_MARGINS = { fine: 5, coarse: 40 };
 
+/**
+ * リサイズハンドルの直前・直後にあるパネルから、スクロール可能なコンテナを取得する。
+ * PanelGroup 内ではハンドルの previous/nextElementSibling が上下パネルに対応する。
+ */
 export function getAdjacentScrollContainers(
   handleElement: HTMLElement
 ): HTMLElement[] {
@@ -33,6 +48,12 @@ export function getAdjacentScrollContainers(
   return containers;
 }
 
+/**
+ * 複数のスクロールコンテナに deltaY を順に適用する。
+ * 上パネル → 下パネルの順で、端までスクロールした分だけ次へ残量を渡す。
+ *
+ * @returns いずれかのコンテナでスクロールが発生した場合 true
+ */
 export function scrollContainersByDelta(
   containers: HTMLElement[],
   deltaY: number

--- a/swa/src/lib/testQuestionScroll.ts
+++ b/swa/src/lib/testQuestionScroll.ts
@@ -1,0 +1,68 @@
+export const TEST_QUESTION_SCROLL_CONTAINER_SELECTOR =
+  "[data-test-question-scroll-container]";
+
+export const TEST_QUESTION_RESIZE_HANDLE_ID_PREFIX =
+  "test-question-resize-handle";
+
+/** タッチ操作時にスクロールと判定する移動量の閾値（px） */
+export const TOUCH_SCROLL_THRESHOLD_PX = 10;
+
+/** タッチ操作時に縦スクロールとみなす縦横比（大きいほどスクロール判定が緩い） */
+export const TOUCH_SCROLL_DOMINANCE_RATIO = 1.2;
+
+/** タッチ向け hit area（既定 coarse: 15 より広い） */
+export const TOUCH_HIT_AREA_MARGINS = { fine: 5, coarse: 40 };
+
+export function getAdjacentScrollContainers(
+  handleElement: HTMLElement
+): HTMLElement[] {
+  const containers: HTMLElement[] = [];
+
+  for (const panel of [
+    handleElement.previousElementSibling,
+    handleElement.nextElementSibling,
+  ]) {
+    const container = panel?.querySelector<HTMLElement>(
+      TEST_QUESTION_SCROLL_CONTAINER_SELECTOR
+    );
+    if (container) {
+      containers.push(container);
+    }
+  }
+
+  return containers;
+}
+
+export function scrollContainersByDelta(
+  containers: HTMLElement[],
+  deltaY: number
+): boolean {
+  let remaining = deltaY;
+
+  for (const container of containers) {
+    if (remaining === 0) {
+      break;
+    }
+
+    const maxScroll = container.scrollHeight - container.clientHeight;
+    if (maxScroll <= 0) {
+      continue;
+    }
+
+    const previousScrollTop = container.scrollTop;
+    const nextScrollTop = Math.max(
+      0,
+      Math.min(maxScroll, previousScrollTop + remaining)
+    );
+    const applied = nextScrollTop - previousScrollTop;
+
+    if (applied === 0) {
+      continue;
+    }
+
+    container.scrollTop = nextScrollTop;
+    remaining -= applied;
+  }
+
+  return remaining !== deltaY;
+}

--- a/swa/src/pages/TestQuestionPage.tsx
+++ b/swa/src/pages/TestQuestionPage.tsx
@@ -185,9 +185,12 @@ export default function TestQuestionPage() {
           direction="vertical"
           className="pt-[52px] min-h-screen w-full"
         >
-          <ResizablePanel defaultSize={60} className="!overflow-visible z-10">
-            <div className="relative h-full overflow-visible">
-              <div className="p-4 h-full min-h-0 overflow-y-auto">
+          <ResizablePanel defaultSize={60} className="z-10">
+            <div className="relative flex h-full min-h-0 flex-col">
+              <div
+                className="flex-1 min-h-0 overflow-y-auto p-4"
+                data-test-question-scroll-container
+              >
                 <SubjectDisplay
                   subjects={questionSelector && questionSelector.subjects}
                   translation={
@@ -201,7 +204,10 @@ export default function TestQuestionPage() {
           </ResizablePanel>
           <TestQuestionResizableHandle withHandle />
           <ResizablePanel defaultSize={40}>
-            <div className="h-full min-h-0 overflow-y-auto bg-slate-200 dark:bg-slate-800">
+            <div
+              className="h-full min-h-0 overflow-y-auto bg-slate-200 dark:bg-slate-800"
+              data-test-question-scroll-container
+            >
               <Selector />
             </div>
           </ResizablePanel>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

daisyUI 移行後に発生していた、テスト問題画面のリサイズハンドル周りのスクロール・タッチ操作のデグレーションを修正しました。

## 変更内容

- `TestQuestionResizableHandle` でホイール操作を上下パネルのスクロールコンテナへ転送し、ハンドル上から画面全体のコンテンツをスクロール可能に復元
- タッチ操作時は縦方向の移動を緩くスクロールと判定（閾値 10px、縦横比 1.2）し、グリップ部分のみリサイズ可能に分離
- タッチ向け `hitAreaMargins` を `coarse: 40` に設定し、リサイズ操作の取りやすさを復元
- `TestQuestionPage` の `ResizablePanel` に付与されていた `overflow-visible` をやめ、`flex` + `min-h-0` レイアウトで問題文・選択肢エリアのスクロール領域を正しく確保
- スクロール補助ロジックを `swa/src/lib/scroll.ts` に配置（旧 `testQuestionScroll.ts` からリネーム）
- `scroll.ts` / `useTestQuestionResizeHandleTouch.ts` に処理概要のコメントを追記

## 技術的な詳細

- スクロール転送ロジックは `swa/src/lib/scroll.ts` に集約
- タッチ向けポインター処理は `swa/src/hooks/useTestQuestionResizeHandleTouch.ts` に分離
- 上下パネルのスクロール対象は `data-test-question-scroll-container` 属性で識別

## テスト内容

- `cd swa && npm run lint` — 成功
- `cd swa && npm run build` — 成功

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c4faa93-1832-4376-b40e-e694efb85f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c4faa93-1832-4376-b40e-e694efb85f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

