### PR TITLE
fix: TestQuestionPageの余分な上下スクロールを修正

### DIFF
--- a/swa/src/pages/TestQuestionPage.tsx
+++ b/swa/src/pages/TestQuestionPage.tsx
@@ -187,7 +187,7 @@ export default function TestQuestionPage() {
           className="pt-[52px] min-h-screen w-full"
         >
           <ResizablePanel defaultSize="60%" className="z-10">
-            <div className="relative flex h-full min-h-0 flex-col">
+            <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
               <div
                 className="flex-1 min-h-0 overflow-y-auto p-4"
                 data-test-question-scroll-container


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`TestQuestionPage` で選択肢を何も選択していない状態のとき、`IconButtonsContainer` の高さの分だけ上部パネルが余分に上下スクロールでき、さらにスクロール後に下部のコンテンツが隠れてしまう不具合を修正する。

## 原因

- `IconButtonsContainer` は `absolute right-4 bottom-4` で配置され、選択肢未選択時は `translate-y-20`(下方向へ80px) + `opacity-0` で非表示にしている。このとき要素はパネル下端から約64px下にはみ出す。
- `react-resizable-panels` を v3 → v4 へアップグレードした際、`Panel` のコンテンツ用 div の既定スタイルが `overflow: hidden`(単一div) から `overflow: auto`(内側div) に変わった。
- その結果、これまでクリップされていた非表示ボタンのはみ出し分(約64px)がスクロール可能領域として露出し、余分なスクロール・下部の見切れが発生していた。

## 変更内容

- `swa/src/pages/TestQuestionPage.tsx` の上部パネルのコンテンツラッパー(`relative flex h-full min-h-0 flex-col`)に `overflow-hidden` を追加し、非表示の `IconButtonsContainer` がパネル外へはみ出してもクリップされるようにした。

## 技術的な詳細

- パネル内側 div の `overflow: auto` は `IconButtonsContainer` のはみ出しを拾ってスクロール領域化していたため、ラッパー側でクリップすることでスクロール領域の増加を根本的に抑止する。
- 選択肢選択時(`translate-y-0`)はボタンが `bottom-4` でパネル内に収まるため、`overflow-hidden` を付与してもボタン表示には影響しない。

## テスト内容

- Puppeteer(Headless Chrome) で実フロー(コース選択→テスト開始→1問目表示)を再現し、上部パネル内側コンテナの `scrollHeight - clientHeight` を測定。
  - 修正前: `64`(余分なスクロールあり、アイコンは `opacity:0` で非表示)
  - 修正後: `0`(余分なスクロールなし)
- 選択肢選択後: 余分スクロールは `0` のまま、`IconButtonsContainer` が `opacity:1` でパネル内に収まって表示されることを確認。
- `npm run lint` / `npm run build` がともに成功することを確認。

## 関連Issue

-
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6208bc56-580a-4d5c-b765-2ed268999da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6208bc56-580a-4d5c-b765-2ed268999da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

