### PR TITLE
fix: fuse-overlayfs上でのCosmosDB Emulator起動失敗を解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ functions/local.settings.json
 # Bicep Parameter Files
 resources/*.parameters.bicepparam
 
+# CosmosDB Emulator
+cosmosdata/
+
 # Python Virtual Environment
 venv/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ QuestionGPTPortal は、Azure OpenAI を活用した英語IT資格試験の学�
 
 ### 重要な注意点
 
-- **Docker in Docker**: `dockerd` の起動・`docker` コマンドは `sudo` が必要（例: `sudo dockerd`、`sudo docker compose up`）。`iptables-legacy` を使用する。
-- **Docker ストレージドライバーは `vfs`**: `/etc/docker/daemon.json` に `{"storage-driver": "vfs"}` を設定済み。`fuse-overlayfs` だと CosmosDB Emulator (vnext-preview) 内部の PostgreSQL が起動時に `could not remove file "base/pgsql_job_cache": Invalid cross-device link` で失敗し、`pgcosmos extension is still starting` のまま使用不能になる。`vfs` に切り替えると `docker compose up` で `PostgreSQL=OK, Gateway=OK, Explorer=OK` となり正常に動作する。この設定は変更しないこと。
+- **Docker in Docker**: `dockerd` の起動・`docker` コマンドは `sudo` が必要（例: `sudo dockerd`、`sudo docker compose up`）。ストレージドライバーは `fuse-overlayfs`、`iptables-legacy` を使用する（`/etc/docker/daemon.json` に設定済み）。
+- **CosmosDB Emulator の PostgreSQL 起動対策**: `fuse-overlayfs` 環境では、イメージ下位レイヤー上のファイル削除が `could not remove file "base/pgsql_job_cache": Invalid cross-device link` (EXDEV) となり、内蔵 PostgreSQL が起動失敗（`pgcosmos extension is still starting` のまま使用不能）する。これを回避するため、`compose.yaml` で CosmosDB の `/data` を名前付きボリューム `cosmosdata` にマウントしている（名前付きボリュームはイメージ内の初期化済み `/data` を自動コピーし、実ファイルシステム上で動作するため EXDEV を回避できる）。正常起動時は `docker compose up` のログに `PostgreSQL=OK, Gateway=OK, Explorer=OK` が出る。ボリュームを完全に作り直したい場合のみ `docker compose down -v` を使う。
 - **認証スキップ**: `import.meta.env.DEV` が true のとき MSAL 認証をスキップし、バックエンドへのリクエストに `X-User-Id: local` ヘッダーを付与する。
 - **Node.js バージョン**: v24 が必要。`nvm use 24` で切り替え可能。
 - **Python venv**: `/workspace/venv` に作成済み。`source /workspace/venv/bin/activate` で有効化。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,15 @@ QuestionGPTPortal は、Azure OpenAI を活用した英語IT資格試験の学�
 
 ### 重要な注意点
 
-- **Docker in Docker**: このVM環境では `fuse-overlayfs` ストレージドライバーと `iptables-legacy` が必要。`/etc/docker/daemon.json` に `{"storage-driver": "fuse-overlayfs"}` を設定済み。
+- **Docker in Docker**: `dockerd` の起動・`docker` コマンドは `sudo` が必要（例: `sudo dockerd`、`sudo docker compose up`）。`iptables-legacy` を使用する。
+- **Docker ストレージドライバーは `vfs`**: `/etc/docker/daemon.json` に `{"storage-driver": "vfs"}` を設定済み。`fuse-overlayfs` だと CosmosDB Emulator (vnext-preview) 内部の PostgreSQL が起動時に `could not remove file "base/pgsql_job_cache": Invalid cross-device link` で失敗し、`pgcosmos extension is still starting` のまま使用不能になる。`vfs` に切り替えると `docker compose up` で `PostgreSQL=OK, Gateway=OK, Explorer=OK` となり正常に動作する。この設定は変更しないこと。
 - **認証スキップ**: `import.meta.env.DEV` が true のとき MSAL 認証をスキップし、バックエンドへのリクエストに `X-User-Id: local` ヘッダーを付与する。
 - **Node.js バージョン**: v24 が必要。`nvm use 24` で切り替え可能。
 - **Python venv**: `/workspace/venv` に作成済み。`source /workspace/venv/bin/activate` で有効化。
 - **`local.settings.json`**: `functions/local.settings.json` はローカル専用（.gitignore済み）。CosmosDB Emulator のデフォルトキーを使用。
 - **`swa/.env`**: `VITE_API_URI="http://localhost:9229"` を設定（.gitignore済み）。
-- **テストデータ**: `functions/data/` に JSON ファイルを配置し `python functions/import_local.py` でインポート。`data/` は .gitignore 済み。
+- **テストデータ**: `functions/data/(コース名)/(テスト名).json` に `list[ImportItem]` 形式の JSON を配置し `python functions/import_local.py` でインポート。`data/` は .gitignore 済み。UI を一通り動かすにはダミーのテストデータを 1 件以上入れておくと便利。
+- **任意のクラウド機能**: 問題への回答（正解・解説生成）は Azure OpenAI、英日翻訳は Azure Translator が必要。`local.settings.json` の `OPENAI_*` / `TRANSLATOR_KEY` が空の場合これらは失敗し、UI に「翻訳失敗」やシステムエラーが出るが想定内。テスト一覧・問題閲覧・お気に入り・進捗などローカル完結の機能は Cosmos/Azurite だけで動作する。
 
 ### lint/test/build コマンド
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,15 +19,15 @@ QuestionGPTPortal は、Azure OpenAI を活用した英語IT資格試験の学�
 
 ### 重要な注意点
 
-- **Docker in Docker**: `dockerd` の起動・`docker` コマンドは `sudo` が必要（例: `sudo dockerd`、`sudo docker compose up`）。ストレージドライバーは `fuse-overlayfs`、`iptables-legacy` を使用する（`/etc/docker/daemon.json` に設定済み）。
-- **CosmosDB Emulator の PostgreSQL 起動対策**: `fuse-overlayfs` 環境では、イメージ下位レイヤー上のファイル削除が `could not remove file "base/pgsql_job_cache": Invalid cross-device link` (EXDEV) となり、内蔵 PostgreSQL が起動失敗（`pgcosmos extension is still starting` のまま使用不能）する。これを回避するため、`compose.yaml` で CosmosDB の `/data` を名前付きボリューム `cosmosdata` にマウントしている（名前付きボリュームはイメージ内の初期化済み `/data` を自動コピーし、実ファイルシステム上で動作するため EXDEV を回避できる）。正常起動時は `docker compose up` のログに `PostgreSQL=OK, Gateway=OK, Explorer=OK` が出る。ボリュームを完全に作り直したい場合のみ `docker compose down -v` を使う。
+- **Docker in Docker**: `dockerd` の起動・`docker` コマンドは `sudo` が必要 (例: `sudo dockerd`、`sudo docker compose up`) 。ストレージドライバーは `fuse-overlayfs`、`iptables-legacy` を使用する (`/etc/docker/daemon.json` に設定済み) 。
+- **CosmosDB Emulator の PostgreSQL 起動対策**: `fuse-overlayfs` 環境では、イメージ下位レイヤー上のファイル削除が `could not remove file "base/pgsql_job_cache": Invalid cross-device link` (EXDEV) となり、内蔵 PostgreSQL が起動失敗 (`pgcosmos extension is still starting` のまま使用不能) する。これを回避するため、`compose.yaml` で CosmosDB の `/data` を名前付きボリューム `cosmosdata` にマウントしている (名前付きボリュームはイメージ内の初期化済み `/data` を自動コピーし、実ファイルシステム上で動作するため EXDEV を回避できる) 。正常起動時は `docker compose up` のログに `PostgreSQL=OK, Gateway=OK, Explorer=OK` が出る。ボリュームを完全に作り直したい場合のみ `docker compose down -v` を使う。
 - **認証スキップ**: `import.meta.env.DEV` が true のとき MSAL 認証をスキップし、バックエンドへのリクエストに `X-User-Id: local` ヘッダーを付与する。
 - **Node.js バージョン**: v24 が必要。`nvm use 24` で切り替え可能。
 - **Python venv**: `/workspace/venv` に作成済み。`source /workspace/venv/bin/activate` で有効化。
-- **`local.settings.json`**: `functions/local.settings.json` はローカル専用（.gitignore済み）。CosmosDB Emulator のデフォルトキーを使用。
-- **`swa/.env`**: `VITE_API_URI="http://localhost:9229"` を設定（.gitignore済み）。
+- **`local.settings.json`**: `functions/local.settings.json` はローカル専用 (.gitignore済み) 。CosmosDB Emulator のデフォルトキーを使用。
+- **`swa/.env`**: `VITE_API_URI="http://localhost:9229"` を設定 (.gitignore済み) 。
 - **テストデータ**: `functions/data/(コース名)/(テスト名).json` に `list[ImportItem]` 形式の JSON を配置し `python functions/import_local.py` でインポート。`data/` は .gitignore 済み。UI を一通り動かすにはダミーのテストデータを 1 件以上入れておくと便利。
-- **任意のクラウド機能**: 問題への回答（正解・解説生成）は Azure OpenAI、英日翻訳は Azure Translator が必要。`local.settings.json` の `OPENAI_*` / `TRANSLATOR_KEY` が空の場合これらは失敗し、UI に「翻訳失敗」やシステムエラーが出るが想定内。テスト一覧・問題閲覧・お気に入り・進捗などローカル完結の機能は Cosmos/Azurite だけで動作する。
+- **任意のクラウド機能**: 問題への回答 (正解・解説生成) は Azure OpenAI、英日翻訳は Azure Translator が必要。`local.settings.json` の `OPENAI_*` / `TRANSLATOR_KEY` が空の場合これらは失敗し、UI に「翻訳失敗」やシステムエラーが出るが想定内。テスト一覧・問題閲覧・お気に入り・進捗などローカル完結の機能は Cosmos/Azurite だけで動作する。
 
 ### lint/test/build コマンド
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,11 +14,10 @@ services:
     environment:
       - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=3
       - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true
-    # /data を名前付きボリュームにマウントし、実ファイルシステム上で内蔵 PostgreSQL を動作させる。
-    # fuse-overlayfs ストレージドライバー環境では、イメージ下位レイヤー上のファイル削除が
-    # "Invalid cross-device link" (EXDEV) となり PostgreSQL が起動失敗するため、それを回避する。
+    # fuse-overlayfsストレージドライバー環境では、イメージ下位レイヤー上のファイル削除が"Invalid cross-device link"(EXDEV)となって
+    # PostgreSQLが起動失敗するため、/dataを名前付きボリュームにマウントし、実ファイルシステム上で内蔵PostgreSQLを動作させることで回避する
     volumes:
-      - cosmosdata:/data
+      - ./cosmosdata:/data
   localstorage:
     image: mcr.microsoft.com/azure-storage/azurite:latest
     container_name: localstorage

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,11 @@ services:
     environment:
       - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=3
       - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true
+    # /data を名前付きボリュームにマウントし、実ファイルシステム上で内蔵 PostgreSQL を動作させる。
+    # fuse-overlayfs ストレージドライバー環境では、イメージ下位レイヤー上のファイル削除が
+    # "Invalid cross-device link" (EXDEV) となり PostgreSQL が起動失敗するため、それを回避する。
+    volumes:
+      - cosmosdata:/data
   localstorage:
     image: mcr.microsoft.com/azure-storage/azurite:latest
     container_name: localstorage
@@ -23,3 +28,6 @@ services:
       - 10002:10002
     volumes:
       - ./azurite:/data
+
+volumes:
+  cosmosdata:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Cloud 上で本リポジトリの開発環境を構築・起動し、全サービス（CosmosDB Emulator / Azurite / Azure Functions バックエンド / Vite フロントエンド）が動作することを確認した。その過程で判明した、`fuse-overlayfs` ストレージドライバー上で CosmosDB Emulator 内蔵の PostgreSQL が起動失敗する問題を、推奨ドライバー（`fuse-overlayfs`）を維持したまま根本解決する。

## 変更内容

- `compose.yaml`: CosmosDB Emulator の `/data` を名前付きボリューム `cosmosdata` にマウント。
- `AGENTS.md`: Docker 起動対策の記述を `fuse-overlayfs` + 名前付きボリュームに更新。`sudo` が必要な点、任意のクラウド機能（OpenAI / Translator）未設定時の挙動、ローカルテストデータの配置方法も整理。

## 技術的な詳細

- `fuse-overlayfs` 環境では、CosmosDB Emulator (vnext-preview) 内蔵 PostgreSQL が起動時にイメージ下位レイヤー上のファイル削除で `could not remove file "base/pgsql_job_cache": Invalid cross-device link` (EXDEV) となり、`pgcosmos extension is still starting` のまま使用不能になる。
- 対策として `/data` を Docker の名前付きボリュームにマウントする。名前付きボリュームはイメージ内の初期化済み `/data` を自動コピーし、実ファイルシステム上で PostgreSQL が動作するため、overlay の whiteout/EXDEV 問題を回避できる。
- 本変更は `compose.yaml` への追加のみで、アプリケーションコードへの変更は含まない。CI（`test-lint.yaml`）はモックでユニットテストを実行し docker compose を使用しないため影響なし。通常の開発端末（Docker Desktop 等）でも安全で、`AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true` と整合する。
- ※当初は `/etc/docker/daemon.json` を `vfs` に切り替える VM レベルの回避策を採用していたが、推奨ドライバーの `fuse-overlayfs` を維持しリポジトリ側で恒久解決する本方式に変更した。

## テスト内容

- インフラ: `sudo docker compose up`（`fuse-overlayfs`）→ ログに `PostgreSQL=OK, Gateway=OK, Explorer=OK`（`Invalid cross-device link` は発生せず）
- Cosmos 初期化: `python functions/import_local.py` → 正常完了（DB/コンテナー/キュー作成・サンプルデータ投入）
- バックエンドユニットテスト: `cd functions && coverage run -m unittest discover -s tests && coverage report -m` → 202 件成功 / カバレッジ 99%
- Pylint: `pylint functions/**/*.py` → 10.00/10
- ESLint: `cd swa && npm run lint` → エラーなし
- フロントエンドビルド: `cd swa && npm run build` → 成功
- 手動 E2E: ランディング → SampleCourse → SampleTest → テスト開始 → 1問目表示 → お気に入り（★）登録を実施し、Cosmos DB へ永続化されること（`favorites` API が `isFavorite: true` を返却）を確認。

## 関連Issue

- なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b72fb08-a1c0-4057-b738-bdec281b5000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b72fb08-a1c0-4057-b738-bdec281b5000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

