### PR TITLE
refactor: azure/arm-deploy から azure/bicep-deploy へ移行

### DIFF
--- a/.github/workflows/create-azure-resources.yaml
+++ b/.github/workflows/create-azure-resources.yaml
@@ -34,31 +34,33 @@ jobs:
         run: az bicep upgrade
 
       - name: Create Resources
-        uses: azure/arm-deploy@v2
+        uses: azure/bicep-deploy@v2
         with:
-          scope: resourcegroup
-          subscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          resourceGroupName: ${{ env.RESOURCE_GROUP }}
-          template: ./resources/base.bicep
-          parameters: >-
-            apimName=${{ vars.APIM_NAME }}
-            azureAdEAContributorObjectId=${{ vars.AZURE_AD_EA_CONTRIBUTOR_OBJECT_ID }}
-            azureApimPublisherEmail=${{ secrets.AZURE_APIM_PUBLISHER_EMAIL }}
-            cosmosDBName=${{ vars.COSMOSDB_NAME }}
-            eventGridName=${{ vars.EVENT_GRID_NAME }}
-            functionsName=${{ vars.FUNCTIONS_NAME }}
-            githubRepoUrl=${{ github.server_url }}/${{ github.repository }}
-            openAIApiVersion=${{ vars.OPENAI_API_VERSION }}
-            openAICapacity=${{ vars.OPENAI_CAPACITY }}
-            openAIDeploymentName=${{ vars.OPENAI_DEPLOYMENT_NAME }}
-            openAILocation=${{ vars.OPENAI_LOCATION }}
-            openAIModelName=${{ vars.OPENAI_MODEL_NAME }}
-            openAIModelVersion=${{ vars.OPENAI_MODEL_VERSION }}
-            openAIName=${{ vars.OPENAI_NAME }}
-            storageName=${{ vars.STORAGE_NAME }}
-            swaName=${{ vars.SWA_NAME }}
-            translatorName=${{ vars.TRANSLATOR_NAME }}
-            vaultName=${{ vars.VAULT_NAME }}
+          type: deployment
+          operation: create
+          scope: resourceGroup
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ env.RESOURCE_GROUP }}
+          template-file: ./resources/base.bicep
+          parameters: |
+            apimName: ${{ vars.APIM_NAME }}
+            azureAdEAContributorObjectId: ${{ vars.AZURE_AD_EA_CONTRIBUTOR_OBJECT_ID }}
+            azureApimPublisherEmail: ${{ secrets.AZURE_APIM_PUBLISHER_EMAIL }}
+            cosmosDBName: ${{ vars.COSMOSDB_NAME }}
+            eventGridName: ${{ vars.EVENT_GRID_NAME }}
+            functionsName: ${{ vars.FUNCTIONS_NAME }}
+            githubRepoUrl: ${{ github.server_url }}/${{ github.repository }}
+            openAIApiVersion: ${{ vars.OPENAI_API_VERSION }}
+            openAICapacity: ${{ vars.OPENAI_CAPACITY }}
+            openAIDeploymentName: ${{ vars.OPENAI_DEPLOYMENT_NAME }}
+            openAILocation: ${{ vars.OPENAI_LOCATION }}
+            openAIModelName: ${{ vars.OPENAI_MODEL_NAME }}
+            openAIModelVersion: ${{ vars.OPENAI_MODEL_VERSION }}
+            openAIName: ${{ vars.OPENAI_NAME }}
+            storageName: ${{ vars.STORAGE_NAME }}
+            swaName: ${{ vars.SWA_NAME }}
+            translatorName: ${{ vars.TRANSLATOR_NAME }}
+            vaultName: ${{ vars.VAULT_NAME }}
 
   # Azure FunctionsのFlex Consumptionプランでは、Azure FunctionsのマネージドIDに対して
   # Azure Storageアカウントへのアクセス権限を付与するロールを割り当てる必要がある
@@ -210,16 +212,18 @@ jobs:
         run: az bicep upgrade
 
       - name: Create Resources
-        uses: azure/arm-deploy@v2
+        uses: azure/bicep-deploy@v2
         with:
-          scope: resourcegroup
-          subscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          resourceGroupName: ${{ env.RESOURCE_GROUP }}
-          template: ./resources/connect-apim-2-functions.bicep
-          parameters: >-
-            apimName=${{ vars.APIM_NAME }}
-            functionsName=${{ vars.FUNCTIONS_NAME }}
-            vaultName=${{ vars.VAULT_NAME }}
+          type: deployment
+          operation: create
+          scope: resourceGroup
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ env.RESOURCE_GROUP }}
+          template-file: ./resources/connect-apim-2-functions.bicep
+          parameters: |
+            apimName: ${{ vars.APIM_NAME }}
+            functionsName: ${{ vars.FUNCTIONS_NAME }}
+            vaultName: ${{ vars.VAULT_NAME }}
 
   use-deploy-functions-app-workflow:
     needs: set-functions-appsettings
@@ -262,12 +266,14 @@ jobs:
         run: az bicep upgrade
 
       - name: Create Resources
-        uses: azure/arm-deploy@v2
+        uses: azure/bicep-deploy@v2
         with:
-          scope: resourcegroup
-          subscriptionId: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          resourceGroupName: ${{ env.RESOURCE_GROUP }}
-          template: ./resources/event-grid-subscription.bicep
-          parameters: >-
-            functionsName=${{ vars.FUNCTIONS_NAME }}
-            eventGridName=${{ vars.EVENT_GRID_NAME }}
+          type: deployment
+          operation: create
+          scope: resourceGroup
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: ${{ env.RESOURCE_GROUP }}
+          template-file: ./resources/event-grid-subscription.bicep
+          parameters: |
+            functionsName: ${{ vars.FUNCTIONS_NAME }}
+            eventGridName: ${{ vars.EVENT_GRID_NAME }}

--- a/.github/workflows/create-azure-resources.yaml
+++ b/.github/workflows/create-azure-resources.yaml
@@ -30,9 +30,6 @@ jobs:
             -n ${{ env.RESOURCE_GROUP }} \
             -l ${{ env.LOCATION }}
 
-      - name: Upgrade Bicep
-        run: az bicep upgrade
-
       - name: Create Resources
         uses: azure/bicep-deploy@v2
         with:
@@ -208,9 +205,6 @@ jobs:
         with:
           creds: '{"clientId":"${{ vars.AZURE_AD_SP_CONTRIBUTOR_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_AD_SP_CONTRIBUTOR_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TENANT_ID }}"}'
 
-      - name: Upgrade Bicep
-        run: az bicep upgrade
-
       - name: Create Resources
         uses: azure/bicep-deploy@v2
         with:
@@ -261,9 +255,6 @@ jobs:
         uses: azure/login@v3
         with:
           creds: '{"clientId":"${{ vars.AZURE_AD_SP_CONTRIBUTOR_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_AD_SP_CONTRIBUTOR_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TENANT_ID }}"}'
-
-      - name: Upgrade Bicep
-        run: az bicep upgrade
 
       - name: Create Resources
         uses: azure/bicep-deploy@v2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

廃止予定の `azure/arm-deploy@v2` を、推奨される後継アクション `azure/bicep-deploy@v2` に移行しました。あわせて、移行後に不要となった `az bicep upgrade` ステップを削除しました。

## 変更内容

- `.github/workflows/create-azure-resources.yaml` の Bicep デプロイステップ（3箇所）を `azure/bicep-deploy@v2` に更新
- 新アクションの必須入力 `type: deployment`、`operation: create`、`scope: resourceGroup` を追加
- 入力名を新形式に合わせて変更（`subscription-id`、`resource-group-name`、`template-file`）
- パラメータ指定を `key=value` 形式から YAML オブジェクト形式へ変換
- `az bicep upgrade` ステップ（3箇所）を削除

## 技術的な詳細

- 対象ジョブ: `create-resources`、`connect-apim-2-functions`、`deploy-event-grid-subscription`
- 旧 `arm-deploy` は `az deployment group create` 経由で Azure CLI 内蔵の Bicep を利用していたため、`az bicep upgrade` が有効だった
- 新 `bicep-deploy` は `downloads.bicep.azure.com` から Bicep CLI を独自にダウンロード・キャッシュし、`bicep-version` 未指定時は最新版を使用するため、`az bicep upgrade` はデプロイに影響しない

## テスト内容

- リポジトリ内の `arm-deploy` 参照および `az bicep upgrade` 参照がすべて除去されたことを確認
- 実際の Azure デプロイは GitHub Actions 上のシークレット/変数が必要なため、本 PR では未実施

## 関連Issue

- なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e1f7a6d-fda7-40ef-8605-b103d8335be4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e1f7a6d-fda7-40ef-8605-b103d8335be4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

