### PR TITLE
fix: 回答済みの途中問題の回答履歴を再保存できるよう修正

### DIFF
--- a/functions/src/post_progress.py
+++ b/functions/src/post_progress.py
@@ -173,40 +173,46 @@ def post_progress(req: func.HttpRequest) -> func.HttpResponse:
             return func.HttpResponse(body="Progress Not exists", status_code=400)
 
         # 指定した問題番号が、テストを解く問題番号の順番における、
-        # 最後に保存した回答履歴の問題番号、またはその次の問題番号であるかのチェック
-        current_question_number: Optional[int] = (
-            item["order"][len(item["progresses"]) - 1]
-            if len(item["progresses"]) > 0
-            else None
-        )
-        next_question_number: Optional[int] = (
-            item["order"][len(item["progresses"])]
-            if len(item["progresses"]) < len(item["order"])
-            else None
-        )
+        # 既に回答履歴を保存済みの問題番号(更新対象)、
+        # またはその次に解くべき問題番号(追加対象)であるかのチェック
+        # 有効な問題番号は order[0 .. len(progresses)] (回答済み + 次の1問)
         logging.info(
             {
-                "current_question_number": current_question_number,
-                "next_question_number": next_question_number,
+                "current_question_number": (
+                    item["order"][len(item["progresses"]) - 1]
+                    if len(item["progresses"]) > 0
+                    else None
+                ),
+                "next_question_number": (
+                    item["order"][len(item["progresses"])]
+                    if len(item["progresses"]) < len(item["order"])
+                    else None
+                ),
             }
         )
-        if question_number not in (current_question_number, next_question_number):
-            msg: str = "questionNumber must be "
-            if len(item["progresses"]) == 0:
-                msg += f"{next_question_number}"
-            elif next_question_number is None:
-                msg += f"{current_question_number}"
-            else:
-                msg += f"{current_question_number} or {next_question_number}"
+
+        # 指定した問題番号が、テストを解く問題番号の順番における何番目かを取得
+        # (順番に存在しない場合はNone)
+        target_index: Optional[int] = (
+            item["order"].index(question_number)
+            if question_number in item["order"]
+            else None
+        )
+
+        # 順番に存在しない、または回答済みでもなくその次でもない(先の問題)の場合はエラー
+        if target_index is None or target_index > len(item["progresses"]):
+            msg: str = "questionNumber must be " + " or ".join(
+                str(number) for number in item["order"][: len(item["progresses"]) + 1]
+            )
             return func.HttpResponse(body=msg, status_code=400)
 
         req_body: PostProgressReq = json.loads(req_body_encoded.decode("utf-8"))
 
-        # 指定した問題番号が、最後に保存した問題番号と同じ場合はupdate、
-        # その次の問題番号の場合はinsertするように、Progressコンテナーの項目を生成
+        # 指定した問題番号が回答済みの場合は該当位置をupdate、
+        # その次に解くべき問題番号の場合はinsertするように、Progressコンテナーの項目を生成
         updated_progresses: List[ProgressElement] = item["progresses"]
-        if question_number == current_question_number:
-            updated_progresses[len(item["progresses"]) - 1] = {
+        if target_index < len(item["progresses"]):
+            updated_progresses[target_index] = {
                 "isCorrect": req_body.get("isCorrect"),
                 "selectedIdxes": req_body.get("selectedIdxes"),
                 "correctIdxes": req_body.get("correctIdxes"),

--- a/functions/tests/test_post_progress.py
+++ b/functions/tests/test_post_progress.py
@@ -634,7 +634,7 @@ class TestPostProgress(unittest.TestCase):
     @patch("src.post_progress.validate_body")
     @patch("src.post_progress.get_read_write_container")
     @patch("src.post_progress.logging")
-    def test_post_progress_invalid_question_number_with_all_progresses(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def test_post_progress_invalid_question_number_not_in_order(  # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         mock_logging,
         mock_get_read_write_container,
@@ -642,7 +642,7 @@ class TestPostProgress(unittest.TestCase):
         mock_validate_headers,
         mock_validate_route_params,
     ):
-        """最後まですべて回答履歴を保存した場合に、誤った問題番号を指定した場合のテスト"""
+        """テストを解く問題番号の順番に存在しない問題番号を指定した場合のテスト"""
 
         mock_validate_route_params.return_value = []
         mock_validate_headers.return_value = []
@@ -692,15 +692,18 @@ class TestPostProgress(unittest.TestCase):
         req = func.HttpRequest(
             method="POST",
             body=request_body_encoded,
-            url="/api/tests/test-id/progresses/5",
-            route_params={"testId": "test-id", "questionNumber": "5"},
+            url="/api/tests/test-id/progresses/6",
+            route_params={"testId": "test-id", "questionNumber": "6"},
             headers={"X-User-Id": "user-id"},
         )
 
         res = post_progress(req)
 
         self.assertEqual(res.status_code, 400)
-        self.assertEqual(res.get_body().decode("utf-8"), "questionNumber must be 4")
+        self.assertEqual(
+            res.get_body().decode("utf-8"),
+            "questionNumber must be 3 or 5 or 1 or 2 or 4",
+        )
         mock_validate_route_params.assert_called_once_with(req.route_params)
         mock_validate_headers.assert_called_once_with(req.headers)
         mock_validate_body.assert_called_once_with(request_body_encoded)
@@ -716,12 +719,133 @@ class TestPostProgress(unittest.TestCase):
             [
                 call(
                     {
-                        "question_number": 5,
+                        "question_number": 6,
                         "test_id": "test-id",
                         "user_id": "user-id",
                     }
                 ),
                 call({"current_question_number": 4, "next_question_number": None}),
+            ]
+        )
+        mock_logging.error.assert_not_called()
+
+    @patch("src.post_progress.validate_route_params")
+    @patch("src.post_progress.validate_headers")
+    @patch("src.post_progress.validate_body")
+    @patch("src.post_progress.get_read_write_container")
+    @patch("src.post_progress.logging")
+    def test_post_progress_update_previous_answered(  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        self,
+        mock_logging,
+        mock_get_read_write_container,
+        mock_validate_body,
+        mock_validate_headers,
+        mock_validate_route_params,
+    ):
+        """途中まで回答済みの状態で、最後ではない回答済みの問題番号を再保存(更新)する場合のテスト"""
+
+        mock_validate_route_params.return_value = []
+        mock_validate_headers.return_value = []
+        mock_validate_body.return_value = []
+        mock_container = MagicMock()
+        mock_get_read_write_container.return_value = mock_container
+        mock_container.read_item.return_value = {
+            "id": "user-id_test-id",
+            "userId": "user-id",
+            "testId": "test-id",
+            "order": [3, 5, 1, 2, 4],
+            "progresses": [
+                {
+                    "isCorrect": True,
+                    "selectedIdxes": [0],
+                    "correctIdxes": [0],
+                },
+                {
+                    "isCorrect": True,
+                    "selectedIdxes": [1],
+                    "correctIdxes": [1],
+                },
+                {
+                    "isCorrect": True,
+                    "selectedIdxes": [2],
+                    "correctIdxes": [2],
+                },
+            ],
+        }
+
+        # order=[3,5,1,2,4]の2問目(問題番号5, 回答済みかつ最後ではない)を再保存
+        request_body = {
+            "isCorrect": False,
+            "selectedIdxes": [3],
+            "correctIdxes": [1],
+        }
+        request_body_encoded = json.dumps(request_body).encode("utf-8")
+        req = func.HttpRequest(
+            method="POST",
+            body=request_body_encoded,
+            url="/api/tests/test-id/progresses/5",
+            route_params={"testId": "test-id", "questionNumber": "5"},
+            headers={"X-User-Id": "user-id"},
+        )
+
+        res = post_progress(req)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            json.loads(res.get_body().decode("utf-8")),
+            [
+                {
+                    "isCorrect": True,
+                    "selectedIdxes": [0],
+                    "correctIdxes": [0],
+                },
+                {
+                    "isCorrect": False,
+                    "selectedIdxes": [3],
+                    "correctIdxes": [1],
+                },
+                {
+                    "isCorrect": True,
+                    "selectedIdxes": [2],
+                    "correctIdxes": [2],
+                },
+            ],
+        )
+        mock_container.upsert_item.assert_called_once_with(
+            {
+                "id": "user-id_test-id",
+                "userId": "user-id",
+                "testId": "test-id",
+                "order": [3, 5, 1, 2, 4],
+                "progresses": [
+                    {
+                        "isCorrect": True,
+                        "selectedIdxes": [0],
+                        "correctIdxes": [0],
+                    },
+                    {
+                        "isCorrect": False,
+                        "selectedIdxes": [3],
+                        "correctIdxes": [1],
+                    },
+                    {
+                        "isCorrect": True,
+                        "selectedIdxes": [2],
+                        "correctIdxes": [2],
+                    },
+                ],
+            }
+        )
+        mock_logging.info.assert_has_calls(
+            [
+                call(
+                    {
+                        "question_number": 5,
+                        "test_id": "test-id",
+                        "user_id": "user-id",
+                    }
+                ),
+                call({"current_question_number": 1, "next_question_number": 2}),
             ]
         )
         mock_logging.error.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

途中の問題から再開後、`PreviousAnsweredQuestionButton` で回答済みの前の問題に戻り、`ResubmitButton` で回答・解説を再生成すると、`NextQuestionButton` が永続的に非活性となり続ける不具合を修正する。

## 原因

`NextQuestionButton` は再生成完了後に `saveProgressAtom` 経由で `[POST] /tests/{testId}/progresses/{questionNumber}` を呼び出し、保存完了で `isSavedProgress` を `true` にして再活性化する設計になっている。

しかし、バックエンドの `post_progress` は「最後に回答した問題」または「次に解くべき問題」の問題番号しか受け付けず、それ以外の回答済みの問題番号には 400 を返していた。`NextQuestionButton` の保存用 `useEffect` はこのエラーを捕捉しないため、`isSavedProgress` が `false` のままとなり、ボタンが永続的に非活性となっていた。

## 変更内容

- `functions/src/post_progress.py` を修正し、テストを解く問題番号の順番(`order`)に存在する回答済みの問題番号であれば、最後でなくても該当位置を update できるようにした。
  - `order` 上のインデックスが回答済みの範囲内: 該当位置を update
  - 回答済みの範囲の次(次に解くべき問題): append
  - 順番に存在しない、またはそれより先の未回答問題: 従来通り 400
- エラーメッセージは有効な問題番号(回答済み + 次の1問)を列挙する形式に統一。

## 技術的な詳細

- 更新は該当インデックスのみで、後続の回答履歴は保持される(再生成では選択肢は変わらないが、`correctIdxes`/`isCorrect` が変化し得るため in-place 更新が妥当)。
- ログ出力の `current_question_number` / `next_question_number` は従来通り維持。

## テスト内容

- `functions` のユニットテスト(unittest + coverage): 全 203 件成功、`post_progress.py` は 100% カバレッジ。
- `pylint functions/**/*.py`: 10.00/10。
- ライブのバックエンド(`func start`)+ CosmosDB エミュレータに対する実機 E2E(curl)で、バグシナリオ(order=[3,5,1,2,4] を 3 問回答後、最後でない回答済み Q5 を再保存 = 途中再開→Previous→Resubmit→保存 相当)を検証。
  - 修正前(origin/main): step5 で `400 questionNumber must be 1 or 2` → 保存失敗 → `isSavedProgress=false` のまま `NextQuestionButton` が永続非活性。
  - 修正後: step5 で `200` を返し、該当 index のみ in-place 更新(長さ・後続は保持)→ `isSavedProgress=true` → ボタン再活性。
- 備考: `ResubmitButton` は Azure OpenAI を呼び出すため、本環境(OpenAI 鍵なし)ではブラウザ E2E は実行できず、失敗していた当該エンドポイントを実機 curl で直接検証した。

## 関連Issue

- なし

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc173cb3-2692-4d7f-9c96-7ba17b48f88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc173cb3-2692-4d7f-9c96-7ba17b48f88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

