### PR TITLE
fix: ChangeQuestionsMenuを1列スクロール表示に修正

### DIFF
--- a/swa/src/components/ChangeQuestionsMenu.tsx
+++ b/swa/src/components/ChangeQuestionsMenu.tsx
@@ -45,7 +45,7 @@ export default function ChangeQuestionsMenu() {
           >
             <Ellipsis className="size-4" />
           </button>
-          <ul className="dropdown-content menu max-h-[75vh] w-max overflow-y-auto rounded-box bg-base-100 shadow-lg">
+          <ul className="dropdown-content menu max-h-[75vh] w-max flex-nowrap overflow-x-hidden overflow-y-auto rounded-box bg-base-100 shadow-lg">
             {Array.from(
               { length: Math.min(histories.length + 1, order.length) },
               (_, idx: number) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`ChangeQuestionsMenu` で問題数が多い場合にメニューが2列へ折り返されてしまう挙動を修正し、1列を維持したまま縦スクロールで閲覧できるようにしました。

## 変更内容

- `ChangeQuestionsMenu` のドロップダウンリストに `flex-nowrap` を追加し、daisyUI `menu` クラスの `flex-wrap: wrap` を上書き
- 既存の `max-h-[75vh]` と `overflow-y-auto` により、高さ超過時は縦スクロールで全項目を閲覧可能に
- 横方向の不要なスクロール防止のため `overflow-x-hidden` を追加

## 技術的な詳細

daisyUI の `.menu` は `flex-flow: column wrap` が既定のため、最大高さを超えると右方向へ2列目が生成されていました。`flex-nowrap` により折り返しを抑止し、単一列 + 縦スクロールのレイアウトに統一しています。

## テスト内容

- `cd swa && npm run lint` — 成功
- `cd swa && npm run build` — 成功

## 関連Issue

- なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ec55bd-77de-4cd9-b311-64247de50017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ec55bd-77de-4cd9-b311-64247de50017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

