### PR TITLE
build: react-router を v8.3.0 へメジャーアップグレード

### DIFF
--- a/swa/package-lock.json
+++ b/swa/package-lock.json
@@ -17,7 +17,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-resizable-panels": "^4.12.2",
-        "react-router": "^7.17.0"
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1783,18 +1783,11 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3211,20 +3204,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -3281,12 +3273,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/swa/package.json
+++ b/swa/package.json
@@ -18,7 +18,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-resizable-panels": "^4.12.2",
-    "react-router": "^7.17.0"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

公式アップグレードガイド（[Upgrading from v7](https://reactrouter.com/upgrading/v7)）に沿い、`react-router` を v7.17.0 から最新の v8.3.0 へメジャーアップグレードしました。

## 変更内容

- `swa/package.json` / `swa/package-lock.json` の `react-router` を `^8.3.0` に更新
- アプリコードの変更なし（declarative モードで既に `react-router` からインポート済み）

## 技術的な詳細

本アプリは declarative モード（`BrowserRouter` / `Routes` / `Route` + hooks）を使用しています。v8 の主な破壊的変更は以下ですが、いずれも本アプリには該当しません。

| 破壊的変更 | 本アプリへの影響 |
|---|---|
| Node `>=22.22.0` / React `>=19.2.7` / Vite `>=7` | 既に満たしている（CI は Node 24、React 19.2.7、Vite 8） |
| `react-router-dom` パッケージ削除 | 未使用（既に `react-router` から import） |
| Framework/Data モード向け Future Flags のデフォルト化 | 未使用 |
| `meta` / `useMatches` の `data` → `loaderData` | 未使用 |

公式 declarative ルーティングドキュメントでも、引き続き `BrowserRouter` / `Routes` / `Route` / hooks は `react-router` からの import が正しいため、既存のルーティング仕様を維持しています。

## テスト内容

- `cd swa && npm run build`（`tsc -b && vite build`）成功
- `cd swa && npm run lint` 成功

### 実行コマンド

```bash
cd swa
npm run build
npm run lint
```

フロントエンドに自動テストは無いため、型チェック付きビルドと ESLint で回帰を確認しています。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0103b4c7-86d1-4f79-a51c-773fdb526848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0103b4c7-86d1-4f79-a51c-773fdb526848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

