### PR TITLE
docs: Cursor Cloud 用の開発環境セットアップ情報を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ uv sync --locked --all-groups
 - **Docker in Docker**: `dockerd` の起動・`docker` コマンドは `sudo` が必要 (例: `sudo dockerd`、`sudo docker compose up`) 。ストレージドライバーは `fuse-overlayfs`、`iptables-legacy` を使用する (`/etc/docker/daemon.json` に設定済み) 。
 - **CosmosDB Emulator の PostgreSQL 起動対策**: `fuse-overlayfs` 環境では、イメージ下位レイヤー上のファイル削除が `could not remove file "base/pgsql_job_cache": Invalid cross-device link` (EXDEV) となり、内蔵 PostgreSQL が起動失敗 (`pgcosmos extension is still starting` のまま使用不能) する。これを回避するため、`compose.yaml` で CosmosDB の `/data` を名前付きボリューム `cosmosdata` にマウントしている (名前付きボリュームはイメージ内の初期化済み `/data` を自動コピーし、実ファイルシステム上で動作するため EXDEV を回避できる) 。正常起動時は `docker compose up` のログに `PostgreSQL=OK, Gateway=OK, Explorer=OK` が出る。ボリュームを完全に作り直したい場合のみ `docker compose down -v` を使う。
 - **認証スキップ**: `import.meta.env.DEV` が true のとき MSAL 認証をスキップし、バックエンドへのリクエストに `X-User-Id: local` ヘッダーを付与する。
-- **Node.js バージョン**: v24 が必要。`nvm use 24` で切り替え可能。
+- **Node.js バージョン**: v24 が必要。ログインシェル (`bash -l`) では `nvm` により自動的に v24 が有効になり、`node` / `npm` / `func` はすべて PATH 上にある。素の非ログインシェルでは `/exec-daemon/node` (v22) が優先されることがあるため、`func start` などが見つからない場合はログインシェルを使うか `nvm use 24` を実行する。
+- **事前導入済みツール**: `uv`・Docker (29.6.2)・Azure Functions Core Tools (`func`) はスナップショットに導入済みで再インストール不要。起動時の更新スクリプトが `uv sync --locked --all-groups` と `npm --prefix swa ci` を自動実行するため、`.venv` と `swa/node_modules` の依存はセッション開始時に最新化される。Docker/CosmosDB/Azurite/`func`/vite などのサービス起動は更新スクリプトに含めず手動で行う (上記「サービス起動順序」参照)。
+- **`func` のグローバル導入時の注意**: `func` は nvm の Node v24 配下にグローバル導入している。npm のグローバル `prefix` を `~/.npmrc` に設定すると nvm と競合し `node` 解決が壊れるため設定しないこと。再導入が必要な場合はログインシェルで Node v24 を有効化してから `npm install -g azure-functions-core-tools@4` を実行する。
 - **Python / uv**: `uv sync --locked --all-groups` で `.venv` を作成。`source .venv/bin/activate` または `uv run` で実行。
 - **`local.settings.json`**: `functions/local.settings.json` はローカル専用 (.gitignore済み) 。CosmosDB Emulator のデフォルトキーを使用。`PYTHON_PATH` は `../.venv/bin/python` を指定。
 - **`swa/.env`**: `VITE_API_URI="http://localhost:9229"` を設定 (.gitignore済み) 。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Cloud エージェント環境で本リポジトリの開発環境を一から構築・起動し、動作確認を行った。その過程で判明した非自明な起動時の注意点を `AGENTS.md` の `## Cursor Cloud specific instructions` に追記する。コード本体の変更はなく、ドキュメントのみの変更。

## 変更内容

- `AGENTS.md` にログインシェルで `node` / `npm` / `func` が PATH 上にある点、非ログインシェルでは `/exec-daemon/node` (v22) が優先され `func` が見つからない場合がある点を追記
- `uv` / Docker (29.6.2) / Azure Functions Core Tools がスナップショットに事前導入済みで、更新スクリプトが `uv sync` と `npm --prefix swa ci` で依存を最新化する旨を追記
- `func` グローバル導入時に npm の `prefix` 設定が nvm と競合する注意点を追記

## 技術的な詳細

セットアップ・動作確認で実施した内容:

- **システム依存**: `uv`、Docker (fuse-overlayfs + iptables-legacy)、Azure Functions Core Tools v4 を導入
- **依存関係**: `uv sync --locked --all-groups`、`swa` で `npm ci`
- **設定ファイル**: `functions/local.settings.json`・`swa/.env` を作成 (いずれも .gitignore 済み)
- **サービス起動**: `docker compose up` (CosmosDB Emulator + Azurite) → `import_local.py` で DB 初期化・サンプルデータ投入 → `func start` (バックエンド:9229) → `npm run dev` (フロントエンド:5173)

## テスト内容

| サービス | コマンド | 結果 |
| --- | --- | --- |
| バックエンド (Python) | `uv run coverage run -m unittest discover -s tests` | 203 件成功 / カバレッジ 99% |
| バックエンド (Pylint) | `uv run pylint functions/**/*.py` | 10.00/10 |
| フロントエンド (ESLint) | `npm run lint` | エラーなし |
| フロントエンド (Build) | `npm run build` | 成功 |
| E2E (手動) | ブラウザで `http://localhost:5173` を操作 | ホーム → テスト一覧 → 問題表示 → 選択肢選択まで正常動作 |

E2E では CosmosDB に投入したサンプルテスト「Sample-Test-01」を開始し、問題文と選択肢が正しく表示され、選択肢の選択がハイライトされることを確認した (Azure OpenAI / Translator は未設定のため AI 系機能は想定通り無効)。

## 関連Issue

- なし
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cab2bd75-2dd3-4750-bdb9-017f92a04582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cab2bd75-2dd3-4750-bdb9-017f92a04582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

